### PR TITLE
Update llmstxt_generator.py

### DIFF
--- a/scripts/llmstxt_generator.py
+++ b/scripts/llmstxt_generator.py
@@ -187,7 +187,7 @@ def generate_llmstxt(url: str, max_pages: int = 30) -> dict:
         # Categorize
         page_entry = {"url": href, "title": link_text}
 
-        if any(kw in path for kw in ["/pricing", "/features", "/product", "/solutions", "/demo"]):
+        if any(kw in path for kw in ["/pricing", "/feature", "/product", "/solution", "/demo"]):
             pages["Products & Services"].append(page_entry)
         elif any(kw in path for kw in ["/blog", "/article", "/resource", "/guide", "/learn", "/docs", "/documentation"]):
             pages["Resources & Blog"].append(page_entry)


### PR DESCRIPTION
It should be /solution which would match /solution/1.html as well as /solutions/1.html.

Same for /feature instead of /features

This is consistent with the usage of the singular form in all other URL path fragments (/article, /career, /partner/, etc.)