### PR TITLE
Standardize import error messages across all scripts

### DIFF
--- a/scripts/brand_scanner.py
+++ b/scripts/brand_scanner.py
@@ -22,7 +22,7 @@ try:
     import requests
     from bs4 import BeautifulSoup
 except ImportError:
-    print("ERROR: Required packages not installed. Run: pip install requests beautifulsoup4")
+    print("ERROR: Required packages not installed. Run: pip install -r requirements.txt")
     sys.exit(1)
 
 DEFAULT_HEADERS = {

--- a/scripts/citability_scorer.py
+++ b/scripts/citability_scorer.py
@@ -19,7 +19,7 @@ try:
     import requests
     from bs4 import BeautifulSoup
 except ImportError:
-    print("ERROR: Required packages not installed. Run: pip install requests beautifulsoup4")
+    print("ERROR: Required packages not installed. Run: pip install -r requirements.txt")
     sys.exit(1)
 
 

--- a/scripts/fetch_page.py
+++ b/scripts/fetch_page.py
@@ -14,7 +14,7 @@ try:
     import requests
     from bs4 import BeautifulSoup
 except ImportError:
-    print("ERROR: Required packages not installed. Run: pip install requests beautifulsoup4")
+    print("ERROR: Required packages not installed. Run: pip install -r requirements.txt")
     sys.exit(1)
 
 # Common AI crawler user agents for testing

--- a/scripts/generate_pdf_report.py
+++ b/scripts/generate_pdf_report.py
@@ -44,7 +44,7 @@ try:
     from reportlab.graphics.charts.piecharts import Pie
     from reportlab.graphics import renderPDF
 except ImportError:
-    print("ERROR: ReportLab is required. Run: pip install reportlab")
+    print("ERROR: Required packages not installed. Run: pip install -r requirements.txt")
     sys.exit(1)
 
 

--- a/scripts/llmstxt_generator.py
+++ b/scripts/llmstxt_generator.py
@@ -18,7 +18,7 @@ try:
     import requests
     from bs4 import BeautifulSoup
 except ImportError:
-    print("ERROR: Required packages not installed. Run: pip install requests beautifulsoup4")
+    print("ERROR: Required packages not installed. Run: pip install -r requirements.txt")
     sys.exit(1)
 
 DEFAULT_HEADERS = {


### PR DESCRIPTION
## Summary

All 5 Python scripts in `scripts/` catch `ImportError` at startup and print an install hint, but the messages were inconsistent:

- 4 scripts said: `pip install requests beautifulsoup4`
- 1 script (`generate_pdf_report.py`) said: `pip install reportlab`

Since the project has a `requirements.txt` with all dependencies pinned, pointing users there is more reliable and ensures they get everything they need in one command.

## Changes

Updated the error message in all 5 scripts to:
```
ERROR: Required packages not installed. Run: pip install -r requirements.txt
```

**Files changed:** `fetch_page.py`, `citability_scorer.py`, `brand_scanner.py`, `llmstxt_generator.py`, `generate_pdf_report.py`

## Test plan

- [x] Verified all 5 scripts have consistent error messages
- [x] `requirements.txt` includes all packages referenced by the scripts (requests, beautifulsoup4, lxml, reportlab)