### PR TITLE
fix: add missing verification warning in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -248,6 +248,11 @@ main() {
     [ -d "$INSTALL_DIR/scripts" ] && print_success "Utility scripts" || { print_error "Scripts missing"; VERIFY_OK=false; }
     [ -d "$INSTALL_DIR/schema" ] && print_success "Schema templates" || { print_error "Schema templates missing"; VERIFY_OK=false; }
 
+    if [ "$VERIFY_OK" = false ]; then
+        echo ""
+        print_warning "One or more files are missing. The install may be incomplete."
+    fi
+
     # ---- Print Summary ----
     echo ""
     echo -e "${GREEN}╔══════════════════════════════════════════╗${NC}"


### PR DESCRIPTION
## Summary
- `install.sh` sets `VERIFY_OK=false` when post-install checks fail but never acts on it
- `install-win.sh` already warns the user in this case (lines 272-275)
- Adds the same warning to `install.sh` for consistency

## Test plan
- [ ] Run `install.sh` with a missing component and confirm the warning is printed
- [ ] Run `install.sh` with all components present and confirm no warning appears