### PR TITLE
fix: add --user flag to pip install in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -210,11 +210,11 @@ main() {
     print_info "Installing Python dependencies..."
 
     if [ -f "$SOURCE_DIR/requirements.txt" ]; then
-        $PYTHON_CMD -m pip install -r "$SOURCE_DIR/requirements.txt" --quiet 2>/dev/null && {
+        $PYTHON_CMD -m pip install --user -r "$SOURCE_DIR/requirements.txt" --quiet 2>/dev/null && {
             print_success "Python dependencies installed"
         } || {
             print_warning "Some Python dependencies failed to install."
-            echo "  Run manually: $PYTHON_CMD -m pip install -r requirements.txt"
+            echo "  Run manually: $PYTHON_CMD -m pip install --user -r requirements.txt"
             cp "$SOURCE_DIR/requirements.txt" "$INSTALL_DIR/"
         }
     fi
@@ -247,6 +247,11 @@ main() {
     [ "$(ls "$AGENTS_DIR"/geo-*.md 2>/dev/null | wc -l)" -gt 0 ] && print_success "Agent files" || { print_error "Agent files missing"; VERIFY_OK=false; }
     [ -d "$INSTALL_DIR/scripts" ] && print_success "Utility scripts" || { print_error "Scripts missing"; VERIFY_OK=false; }
     [ -d "$INSTALL_DIR/schema" ] && print_success "Schema templates" || { print_error "Schema templates missing"; VERIFY_OK=false; }
+
+    if [ "$VERIFY_OK" = false ]; then
+        echo ""
+        print_warning "One or more files are missing. The install may be incomplete."
+    fi
 
     # ---- Print Summary ----
     echo ""


### PR DESCRIPTION
## Summary
- `install-win.sh` already uses `pip install --user` to avoid requiring admin/root privileges
- `install.sh` was missing this flag, which can cause permission errors on systems without a virtualenv active
- Adds `--user` to both the install command and the fallback manual instruction

## Test plan
- [ ] Run `install.sh` without root/virtualenv and confirm pip install succeeds with `--user`
- [ ] Verify the fallback message includes `--user` when pip fails