### PR TITLE
fix: handle non-interactive mode in uninstall.sh

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -9,6 +9,12 @@ CLAUDE_DIR="${HOME}/.claude"
 SKILLS_DIR="${CLAUDE_DIR}/skills"
 AGENTS_DIR="${CLAUDE_DIR}/agents"
 
+# Detect if running via curl pipe (no interactive input available)
+INTERACTIVE=true
+if [ ! -t 0 ]; then
+    INTERACTIVE=false
+fi
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -31,12 +37,15 @@ for agent_file in "$AGENTS_DIR"/geo-*.md; do
 done
 
 echo ""
-read -p "Are you sure you want to uninstall? (y/n): " -n 1 -r
-echo ""
-
-if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    echo "Uninstall cancelled."
-    exit 0
+if [ "$INTERACTIVE" = true ]; then
+    read -p "Are you sure you want to uninstall? (y/n): " -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Uninstall cancelled."
+        exit 0
+    fi
+else
+    echo -e "${YELLOW}Non-interactive mode — proceeding with uninstall...${NC}"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- `uninstall.sh` uses `read -p` for confirmation but has no non-interactive detection
- When piped via `curl | bash`, the script hangs waiting for input
- Both install scripts already handle this correctly — adds the same pattern to `uninstall.sh`

## Test plan
- [ ] Run `uninstall.sh` interactively and confirm the y/n prompt still works
- [ ] Run `echo "" | bash uninstall.sh` and confirm it proceeds without hanging