### PR TITLE
fix: use fetch_page.py instead of WebFetch for schema detection

### DIFF
--- a/agents/geo-schema.md
+++ b/agents/geo-schema.md
@@ -14,9 +14,15 @@ You are a schema markup specialist. Your job is to analyze a target URL for exis
 
 ## Execution Steps
 
+**IMPORTANT:** WebFetch converts HTML to markdown and strips `<head>` content, which removes JSON-LD blocks. For schema detection, use the fetch_page.py script instead:
+```bash
+python3 ~/.claude/skills/geo/scripts/fetch_page.py <url> page
+```
+The output includes a `structured_data` array with all parsed JSON-LD blocks from the page.
+
 ### Step 1: Detect Existing Structured Data
 
-Fetch the target URL with WebFetch and scan the full HTML source for structured data in all three formats:
+Fetch the target URL using `fetch_page.py` (see above) and scan the full HTML source for structured data in all three formats:
 
 **JSON-LD (Preferred):**
 - Search for `<script type="application/ld+json">` tags.

--- a/skills/geo-schema/SKILL.md
+++ b/skills/geo-schema/SKILL.md
@@ -14,7 +14,7 @@ Structured data is the primary machine-readable signal that tells AI systems wha
 
 ## How to Use This Skill
 
-1. Fetch the target page HTML using curl or WebFetch
+1. Fetch the target page HTML using `fetch_page.py` (see note below)
 2. Detect all existing structured data (JSON-LD, Microdata, RDFa)
 3. Validate detected schemas against Schema.org specifications
 4. Identify missing recommended schemas based on business type
@@ -24,6 +24,12 @@ Structured data is the primary machine-readable signal that tells AI systems wha
 ---
 
 ## Step 1: Detection
+
+**IMPORTANT:** WebFetch converts HTML to markdown and strips `<head>` content, which removes JSON-LD blocks. Use `fetch_page.py` instead:
+```bash
+python3 ~/.claude/skills/geo/scripts/fetch_page.py <url> page
+```
+The output includes a `structured_data` array with all parsed JSON-LD blocks from the page.
 
 ### Scan for JSON-LD
 Look for `<script type="application/ld+json">` blocks in the HTML. Parse each block as JSON. A page may contain multiple JSON-LD blocks — collect all of them.


### PR DESCRIPTION
## Summary
- WebFetch strips `<head>` content during HTML-to-markdown conversion
- JSON-LD blocks sit in `<head>`, making them invisible to the schema audit
- Updates `geo-schema` agent and skill to use `fetch_page.py` (which correctly extracts JSON-LD) instead of WebFetch

## Test plan
- [ ] Run `/geo schema <url>` on a site with JSON-LD in `<head>` and confirm it detects the structured data
- [ ] Verify `fetch_page.py <url> page` output includes `structured_data` array

Closes #16