### PR TITLE
fix: add missing allowed-tools declarations to 6 skills

### DIFF
--- a/skills/geo-content/SKILL.md
+++ b/skills/geo-content/SKILL.md
@@ -4,6 +4,7 @@ description: Content quality and E-E-A-T assessment for AI citability — evalua
 version: 1.0.0
 author: geo-seo-claude
 tags: [geo, content-quality, eeat, citability, ai-content, topical-authority]
+allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
 ---
 
 # GEO Content Quality & E-E-A-T Assessment

--- a/skills/geo-platform-optimizer/SKILL.md
+++ b/skills/geo-platform-optimizer/SKILL.md
@@ -4,6 +4,7 @@ description: Platform-specific AI search optimization — audit and optimize for
 version: 1.0.0
 author: geo-seo-claude
 tags: [geo, ai-search, platform-optimization, chatgpt, perplexity, gemini, aio]
+allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
 ---
 
 # GEO Platform Optimizer

--- a/skills/geo-report-pdf/SKILL.md
+++ b/skills/geo-report-pdf/SKILL.md
@@ -4,6 +4,7 @@ description: Generate a professional PDF report from GEO audit data using Report
 version: 1.0.0
 author: geo-seo-claude
 tags: [geo, pdf, report, client-deliverable, professional]
+allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
 ---
 
 # GEO PDF Report Generator

--- a/skills/geo-report/SKILL.md
+++ b/skills/geo-report/SKILL.md
@@ -4,6 +4,7 @@ description: Generate a professional, client-facing GEO report combining all aud
 version: 1.0.0
 author: geo-seo-claude
 tags: [geo, report, client-deliverable, executive-summary, action-plan]
+allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
 ---
 
 # GEO Client Report Generator

--- a/skills/geo-schema/SKILL.md
+++ b/skills/geo-schema/SKILL.md
@@ -4,6 +4,7 @@ description: Schema.org structured data audit and generation optimized for AI di
 version: 1.0.0
 author: geo-seo-claude
 tags: [geo, schema, structured-data, json-ld, entity-recognition, ai-discoverability]
+allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
 ---
 
 # GEO Schema & Structured Data

--- a/skills/geo-technical/SKILL.md
+++ b/skills/geo-technical/SKILL.md
@@ -4,6 +4,7 @@ description: Technical SEO audit with GEO-specific checks — crawlability, inde
 version: 1.0.0
 author: geo-seo-claude
 tags: [geo, technical-seo, core-web-vitals, ssr, crawlability, security, performance]
+allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
 ---
 
 # GEO Technical SEO Audit


### PR DESCRIPTION
## Summary
- 6 of the 13 sub-skills had no `allowed-tools` in their YAML frontmatter
- This may prevent Claude Code from executing tool operations during skill invocation
- Adds the standard tool set (`Read, Grep, Glob, Bash, WebFetch, Write`) matching the main `geo` skill and the 7 sub-skills that already declare it

### Skills updated
- `geo-content`, `geo-platform-optimizer`, `geo-report-pdf`, `geo-report`, `geo-schema`, `geo-technical`

## Test plan
- [ ] Run each updated skill individually and confirm tools are available
- [ ] Verify the YAML frontmatter parses correctly (no syntax errors)