### PR TITLE
Add live AI crawler reachability probe (geo-botaccess)

### DIFF
--- a/scripts/fetch_page.py
+++ b/scripts/fetch_page.py
@@ -7,6 +7,7 @@ Extracts HTML, text content, meta tags, headers, and structured data.
 import sys
 import json
 import re
+from difflib import SequenceMatcher
 from urllib.parse import urljoin, urlparse
 
 try:
@@ -16,14 +17,110 @@ except ImportError:
     print("ERROR: Required packages not installed. Run: pip install -r requirements.txt")
     sys.exit(1)
 
-# Common AI crawler user agents for testing
+# AI crawler user agents used for live probing.
+#
+# This dict is consumed both by ad-hoc fetches in this module and by
+# probe_ai_crawlers() below, which replays the homepage as each of these
+# bots to detect WAF/Cloudflare blocking that static robots.txt analysis
+# cannot see. The list covers three groups:
+#
+#   1. AI search bots — power user-facing AI search products (ChatGPT,
+#      Claude, Perplexity, Gemini, Bing Copilot, Apple Intelligence).
+#      Blocking these directly removes a site from AI answers.
+#   2. Traditional search bots — Googlebot and Bingbot. Listed because
+#      sites that block these via WAF lose regular search visibility,
+#      which is almost always unintentional and worth flagging loudly.
+#   3. Training-only crawlers — CCBot, Bytespider, Meta-ExternalAgent,
+#      Cohere-ai. Often deliberately blocked, which is fine; included
+#      so the report shows the full picture.
 AI_CRAWLERS = {
+    # AI search bots (Tier 1 — most important to allow)
     "GPTBot": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; GPTBot/1.2; +https://openai.com/gptbot)",
+    "ChatGPT-User": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; ChatGPT-User/1.0; +https://openai.com/bot)",
     "ClaudeBot": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; ClaudeBot/1.0; +https://www.anthropic.com/claude-bot)",
+    "anthropic-ai": "anthropic-ai/1.0",
     "PerplexityBot": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)",
+    "Google-Extended": "Mozilla/5.0 (compatible; Google-Extended/1.0; +http://www.google.com/bot.html)",
+    "Applebot-Extended": "Mozilla/5.0 (compatible; Applebot-Extended/1.0)",
+    # Traditional search bots (blocking these is usually a mistake)
     "GoogleBot": "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
     "BingBot": "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)",
+    # Training-only crawlers (often deliberately blocked)
+    "CCBot": "CCBot/2.0 (+https://commoncrawl.org/faq/)",
+    "Bytespider": "Bytespider/1.0",
+    "Meta-ExternalAgent": "Meta-ExternalAgent/1.0 (+https://www.meta.com/)",
+    "cohere-ai": "cohere-ai/1.0",
 }
+
+# Bots that power AI search products users actively interact with.
+# Used by probe_ai_crawlers() and downstream skills to weight findings:
+# a 403 to one of these is a critical issue, while a 403 to a training
+# crawler may be intentional.
+AI_SEARCH_BOTS = {
+    "GPTBot", "ChatGPT-User", "ClaudeBot", "PerplexityBot",
+    "Google-Extended", "Applebot-Extended", "GoogleBot", "BingBot",
+}
+
+# Substrings that indicate a Cloudflare interstitial / challenge page
+# rather than real site content. Used both on the browser baseline
+# (to detect that we need a Playwright fallback) and on individual bot
+# responses (to detect "200 OK" responses that are actually challenge
+# pages disguised as success).
+CF_CHALLENGE_MARKERS = (
+    "cf-challenge",
+    "cf-turnstile",
+    "ray id",
+    "checking your browser",
+    "attention required",
+    "just a moment",
+    "enable javascript and cookies",
+    "cf-chl-bypass",
+    "challenge-platform",
+)
+
+# WAF / CDN fingerprints. Each entry is (product_name, predicate, evidence)
+# where the predicate is called with two pre-normalised arguments:
+#
+#   headers_lower:  dict[str, str] of response headers, both keys and
+#                   values lowercased for case-insensitive matching
+#   cookies_blob:   one big lowercase string with all Set-Cookie values
+#                   concatenated, for cheap "name in blob" cookie tests
+#
+# Identifying the specific product matters because remediation differs
+# completely per product. "Allow GPTBot in Cloudflare" is a different
+# procedure than "Allow GPTBot in Imperva" or "Allow GPTBot in AWS WAF".
+# Skills that consume this data give product-specific dashboard paths
+# in their recommendations, which is far more actionable than a generic
+# "configure your WAF" suggestion.
+#
+# Multiple products can legitimately stack (e.g. Cloudflare in front of
+# AWS ELB), so detect_waf() returns a list rather than a single value.
+WAF_FINGERPRINTS = (
+    ("Cloudflare", lambda h, c: "cf-ray" in h, "cf-ray header"),
+    ("Cloudflare", lambda h, c: "cloudflare" in h.get("server", ""), "server: cloudflare"),
+    ("Cloudflare", lambda h, c: any(n in c for n in ("__cf_bm", "cf_clearance", "__cfduid")), "cf_bm/cf_clearance cookie"),
+    ("AWS CloudFront", lambda h, c: "x-amz-cf-id" in h, "x-amz-cf-id header"),
+    ("AWS WAF", lambda h, c: "x-amzn-waf-action" in h, "x-amzn-waf-action header"),
+    ("AWS ELB", lambda h, c: "awselb" in h.get("server", ""), "server: awselb"),
+    ("Akamai", lambda h, c: "akamaighost" in h.get("server", "") or "akamai" in h.get("server", ""), "server: AkamaiGHost"),
+    ("Akamai", lambda h, c: any(k.startswith("x-akamai") for k in h), "x-akamai-* header"),
+    ("Akamai", lambda h, c: "akamai-grn" in h, "akamai-grn header"),
+    ("Sucuri", lambda h, c: "sucuri" in h.get("server", ""), "server: sucuri/cloudproxy"),
+    ("Sucuri", lambda h, c: "x-sucuri-id" in h or "x-sucuri-cache" in h, "x-sucuri-* header"),
+    ("Imperva Incapsula", lambda h, c: "x-iinfo" in h, "x-iinfo header"),
+    ("Imperva Incapsula", lambda h, c: "incapsula" in h.get("x-cdn", ""), "x-cdn: Incapsula"),
+    ("Imperva Incapsula", lambda h, c: "incap_ses" in c or "visid_incap" in c, "incap_ses cookie"),
+    ("F5 BIG-IP", lambda h, c: "big-ip" in h.get("server", "") or "bigip" in h.get("server", ""), "server: BIG-IP"),
+    ("F5 BIG-IP", lambda h, c: "bigipserver" in c, "BIGipServer cookie"),
+    ("F5 BIG-IP ASM", lambda h, c: "x-waf-event-info" in h, "x-waf-event-info header"),
+    ("Fastly", lambda h, c: "x-fastly-request-id" in h, "x-fastly-request-id header"),
+    ("Fastly", lambda h, c: "fastly" in h.get("server", ""), "server: fastly"),
+    ("Barracuda WAF", lambda h, c: "barra_counter_session" in c, "barra_counter_session cookie"),
+    ("Wallarm", lambda h, c: "nginx-wallarm" in h or "wallarm" in h.get("server", ""), "wallarm header"),
+    ("Azure Front Door", lambda h, c: "x-azure-ref" in h, "x-azure-ref header"),
+    ("StackPath", lambda h, c: any(k.startswith("x-sp-") for k in h), "x-sp-* header"),
+    ("Google Frontend", lambda h, c: "google frontend" in h.get("server", ""), "server: Google Frontend"),
+)
 
 DEFAULT_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
@@ -390,6 +487,258 @@ def extract_content_blocks(html: str) -> list:
     return blocks
 
 
+def is_challenge_page(html: str, status_code: int) -> bool:
+    """Detect a Cloudflare interstitial / WAF block page disguised as content.
+
+    Cloudflare and similar products serve HTML challenge pages that look
+    like real responses (sometimes even with a 200 status). The body
+    contains characteristic markers like ``cf-challenge`` or
+    "Checking your browser". We check the first 8 KB only because the
+    markers always appear early in the document and bounding the check
+    keeps it cheap on large pages.
+    """
+    head = (html or "")[:8000].lower()
+    if status_code in (403, 503):
+        if any(m in head for m in CF_CHALLENGE_MARKERS):
+            return True
+        # Cloudflare's own error pages are clearly branded — treat any
+        # 403/503 served from Cloudflare as a challenge for the purposes
+        # of "did this bot reach the real content".
+        if "cloudflare" in head:
+            return True
+    if status_code == 200:
+        if any(m in head for m in CF_CHALLENGE_MARKERS):
+            return True
+    return False
+
+
+def detect_waf(response) -> list:
+    """Fingerprint WAF/CDN products from response headers and cookies.
+
+    Returns a list of ``{"product": str, "evidence": str}`` dicts. Multiple
+    products may stack legitimately (e.g. Cloudflare in front of an AWS
+    ELB), so the function never short-circuits — it walks the full
+    fingerprint table and de-duplicates by product name, keeping the
+    first piece of evidence found for each.
+
+    Pure function over the headers, so it's trivial to unit-test by
+    constructing a fake response object.
+    """
+    headers_lower = {k.lower(): str(v).lower() for k, v in response.headers.items()}
+
+    # Some servers send Set-Cookie multiple times. requests exposes them
+    # via the underlying response.raw object or via response.cookies, but
+    # the cleanest cross-version path is to flatten the headers we already
+    # have. We just need a string for substring matching.
+    cookie_blob = headers_lower.get("set-cookie", "")
+
+    seen = set()
+    detected = []
+    for product, predicate, evidence in WAF_FINGERPRINTS:
+        if product in seen:
+            continue
+        try:
+            if predicate(headers_lower, cookie_blob):
+                detected.append({"product": product, "evidence": evidence})
+                seen.add(product)
+        except Exception:
+            # A broken fingerprint should never break the whole scan.
+            # Swallow and continue so a single bad predicate doesn't
+            # take out detection for every other product.
+            pass
+    return detected
+
+
+def _playwright_baseline(url: str, timeout_ms: int = 30000):
+    """Fetch ``url`` with a real headless browser, for JS-challenged sites.
+
+    Returns ``(status, html)`` on success or ``None`` if Playwright isn't
+    installed or the fetch fails. We import inside the function so the
+    rest of fetch_page.py keeps working when Playwright is missing —
+    Playwright is in requirements.txt but graceful degradation matters
+    for users on minimal installs.
+    """
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        return None
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            ctx = browser.new_context(user_agent=DEFAULT_HEADERS["User-Agent"])
+            page = ctx.new_page()
+            resp = page.goto(url, wait_until="networkidle", timeout=timeout_ms)
+            status = resp.status if resp else 200
+            html = page.content()
+            browser.close()
+            return status, html
+    except Exception:
+        return None
+
+
+def _content_similarity(a: str, b: str) -> float:
+    """Cheap text-similarity score in [0, 1] for the first 10 KB of two pages.
+
+    Used to catch the case where a bot receives HTTP 200 with a totally
+    different (often stripped or generic) body than the browser baseline.
+    SequenceMatcher is good enough here — we don't need linguistic
+    analysis, just "are these obviously the same page". The 10 KB cap
+    keeps the comparison constant-time on long articles.
+    """
+    def normalise(text: str) -> str:
+        return re.sub(r"\s+", " ", (text or "")[:10000]).strip().lower()
+    return SequenceMatcher(None, normalise(a), normalise(b)).ratio()
+
+
+def probe_ai_crawlers(url: str, timeout: int = 15) -> dict:
+    """Live-probe a URL with AI crawler user-agents to detect WAF blocking.
+
+    This is the empirical complement to ``fetch_robots_txt``. Static
+    robots.txt analysis tells you what a site *declares*; this function
+    tells you what AI bots *actually* receive. The two often disagree:
+    a site can have a permissive robots.txt while a Cloudflare bot
+    management rule silently returns 403 to GPTBot, ClaudeBot, and
+    Googlebot. The declared policy looks fine; the live reality is
+    that AI search products see nothing.
+
+    Workflow:
+
+      1. Fetch a browser baseline so we know what real content looks
+         like (size, body, headers).
+      2. Detect Cloudflare JS challenges on that baseline. If found,
+         try a Playwright headless fallback so we have a usable
+         reference for similarity comparison. If Playwright is missing,
+         we degrade gracefully and rely on status-code / challenge-body
+         detection alone.
+      3. Fingerprint WAF/CDN products from the baseline headers — this
+         drives product-specific remediation in downstream skills.
+      4. Replay the request as each AI crawler in AI_CRAWLERS, comparing
+         status, body length, and content similarity to the baseline.
+         A bot is considered blocked if any of:
+            - status is 403, 406, 429, or 503
+            - body matches Cloudflare challenge markers (200 with a
+              disguised block page)
+            - body is non-trivially smaller AND content similarity to
+              baseline is suspiciously low (silent content stripping)
+
+    Returns a dict structured for JSON consumption by skills. All
+    failures are captured in result["errors"] rather than raised — this
+    matches the error-handling pattern used elsewhere in fetch_page.py.
+    """
+    result = {
+        "url": url,
+        "baseline": {
+            "status": None,
+            "length": None,
+            "used_playwright": False,
+        },
+        "js_challenge_detected": False,
+        "wafs_detected": [],
+        "probes": [],
+        "errors": [],
+    }
+
+    # --- 1. Browser baseline -------------------------------------------------
+    try:
+        baseline_resp = requests.get(
+            url, headers=DEFAULT_HEADERS, timeout=timeout, allow_redirects=True
+        )
+    except Exception as e:
+        result["errors"].append(f"Baseline fetch failed: {e}")
+        return result
+
+    baseline_html = baseline_resp.text or ""
+    result["baseline"]["status"] = baseline_resp.status_code
+    result["baseline"]["length"] = len(baseline_html)
+
+    # --- 2. JS challenge detection + optional Playwright fallback -----------
+    if is_challenge_page(baseline_html, baseline_resp.status_code):
+        result["js_challenge_detected"] = True
+        pw = _playwright_baseline(url)
+        if pw is not None:
+            pw_status, pw_html = pw
+            if not is_challenge_page(pw_html, pw_status):
+                # Playwright successfully bypassed the challenge — use
+                # its rendered output as the comparison baseline so the
+                # similarity scores below are meaningful.
+                baseline_html = pw_html
+                result["baseline"]["status"] = pw_status
+                result["baseline"]["length"] = len(pw_html)
+                result["baseline"]["used_playwright"] = True
+
+    # --- 3. WAF / CDN fingerprinting ----------------------------------------
+    # Run on the original requests response — Playwright bypassed the
+    # challenge for the body, but the original headers are what tell us
+    # which product is in front of the site.
+    result["wafs_detected"] = detect_waf(baseline_resp)
+
+    # --- 4. Per-bot probes ---------------------------------------------------
+    # If the baseline is itself a challenge page that Playwright couldn't
+    # bypass, similarity comparison is meaningless (every bot will look
+    # "similar" to a challenge page). In that case we fall back to pure
+    # status-code / challenge-marker detection.
+    baseline_is_challenge = (
+        result["js_challenge_detected"] and not result["baseline"]["used_playwright"]
+    )
+
+    for bot_name, bot_ua in AI_CRAWLERS.items():
+        probe = {
+            "bot": bot_name,
+            "user_agent": bot_ua,
+            "status": None,
+            "length": None,
+            "similarity": None,
+            "blocked": False,
+            "block_reason": None,
+        }
+        try:
+            bot_resp = requests.get(
+                url,
+                headers={**DEFAULT_HEADERS, "User-Agent": bot_ua},
+                timeout=timeout,
+                allow_redirects=True,
+            )
+        except Exception as e:
+            probe["blocked"] = True
+            probe["block_reason"] = f"request_error: {e}"
+            result["probes"].append(probe)
+            continue
+
+        bot_html = bot_resp.text or ""
+        probe["status"] = bot_resp.status_code
+        probe["length"] = len(bot_html)
+
+        # Block detection rules in priority order. We record the first
+        # rule that matches so the downstream skill can give a precise
+        # explanation in its recommendations.
+        if bot_resp.status_code in (403, 406, 429, 503):
+            probe["blocked"] = True
+            probe["block_reason"] = f"http_{bot_resp.status_code}"
+        elif is_challenge_page(bot_html, bot_resp.status_code):
+            probe["blocked"] = True
+            probe["block_reason"] = "challenge_page"
+        elif not baseline_is_challenge:
+            # Compare against the real browser baseline. We only flag
+            # via similarity when both the body is much smaller AND the
+            # similarity is low — either signal alone has too many false
+            # positives (mobile-optimised pages, A/B tests, etc.).
+            similarity = _content_similarity(baseline_html, bot_html)
+            probe["similarity"] = round(similarity, 3)
+            length_ratio = (
+                probe["length"] / result["baseline"]["length"]
+                if result["baseline"]["length"]
+                else 1.0
+            )
+            if similarity < 0.4 and length_ratio < 0.5:
+                probe["blocked"] = True
+                probe["block_reason"] = "content_stripped"
+
+        result["probes"].append(probe)
+
+    return result
+
+
 def crawl_sitemap(url: str, max_pages: int = 50, timeout: int = 15) -> list:
     """Crawl sitemap.xml to discover pages."""
     parsed = urlparse(url)
@@ -453,7 +802,7 @@ def crawl_sitemap(url: str, max_pages: int = 50, timeout: int = 15) -> list:
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Usage: python fetch_page.py <url> [mode]")
-        print("Modes: page (default), robots, llms, sitemap, blocks, full")
+        print("Modes: page (default), robots, llms, sitemap, blocks, bots, full")
         sys.exit(1)
 
     target_url = sys.argv[1]
@@ -471,12 +820,17 @@ if __name__ == "__main__":
     elif mode == "blocks":
         response = requests.get(target_url, headers=DEFAULT_HEADERS, timeout=30)
         data = extract_content_blocks(response.text)
+    elif mode == "bots":
+        # Live AI crawler reachability probe — empirical complement to
+        # the static `robots` mode. See probe_ai_crawlers() for details.
+        data = probe_ai_crawlers(target_url)
     elif mode == "full":
         data = {
             "page": fetch_page(target_url),
             "robots": fetch_robots_txt(target_url),
             "llms": fetch_llms_txt(target_url),
             "sitemap": crawl_sitemap(target_url),
+            "bots": probe_ai_crawlers(target_url),
         }
     else:
         print(f"Unknown mode: {mode}")

--- a/skills/geo-botaccess/SKILL.md
+++ b/skills/geo-botaccess/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: geo-botaccess
+description: Live AI crawler reachability test. Probes a website with real AI bot user-agents (GPTBot, ClaudeBot, PerplexityBot, Googlebot, Bingbot, etc.) to detect WAF/Cloudflare blocking that static robots.txt analysis cannot see. Use this skill whenever the user asks "can ChatGPT/Claude/Perplexity read my site", "is GPTBot/Googlebot blocked on X", "is Cloudflare blocking AI bots", "WAF blocking AI crawlers", "why isn't my site showing up in AI answers", "test bot access", "re-check after I fixed the WAF rule", or wants any empirical test of AI crawler reachability on a specific URL. Unlike geo-crawlers which reads declared policy, this skill measures what bots actually receive — perfect for the iterative fix-and-retest loop.
+version: 1.0.0
+author: geo-seo-claude
+tags: [geo, ai-crawlers, waf, cloudflare, bot-access, empirical]
+allowed-tools: Read, Bash, Write
+---
+
+# GEO Bot Access — Live AI Crawler Reachability Probe
+
+## Purpose
+
+`geo-crawlers` reads declared policy: it parses `robots.txt` and meta tags to figure out what a site *says* about AI crawlers. That's necessary but not sufficient. A site can have a permissive `robots.txt` while a Cloudflare bot management rule, an AWS WAF custom rule, or an Imperva bot allowlist silently returns `HTTP 403` to GPTBot, ClaudeBot, and Googlebot. The declared policy looks fine. The live reality is that AI search products see nothing.
+
+This skill closes that gap. It runs a live empirical probe — fetching the site with each AI crawler user-agent and recording what comes back — and surfaces declared-vs-actual mismatches as critical findings.
+
+It's deliberately scoped to be fast enough to run on every iteration of a fix-and-retest loop. When a user makes a Cloudflare WAF rule change or updates their bot management settings, they should be able to invoke this skill to verify the fix without waiting for a full audit.
+
+## When to use this skill
+
+Use it any time the user wants ground-truth AI crawler reachability for a specific URL. Triggering phrases include but are not limited to:
+
+- "Can ChatGPT / Claude / Perplexity read my site?"
+- "Is GPTBot blocked on example.com?"
+- "Is Cloudflare blocking AI bots?"
+- "Why isn't my site showing up in AI answers / ChatGPT search / Perplexity?"
+- "Test bot access for X"
+- "Re-check after I fixed the WAF rule"
+- "Audit AI crawler reachability"
+- "Run a bot access scan"
+
+If the user only wants a static review of `robots.txt` directives, prefer `geo-crawlers`. If the user wants the full GEO audit, use `geo-audit` (which calls `geo-technical`, which calls this same probe internally — so the bot check is included automatically).
+
+## How it works
+
+The probe is implemented as the `bots` mode of `scripts/fetch_page.py`. It does the following in one pass:
+
+1. **Browser baseline** — fetches the URL with a normal Chrome user-agent so we know what real content looks like (size, body, headers).
+2. **JS challenge detection** — checks the baseline body for Cloudflare challenge markers (`cf-challenge`, `cf-turnstile`, "checking your browser", etc.). If a challenge is detected, the probe transparently falls back to a Playwright headless browser fetch so the comparison baseline is real content rather than a block page. If Playwright isn't installed, the probe degrades gracefully and switches to status-only block detection.
+3. **WAF / CDN fingerprinting** — inspects the baseline response headers and `Set-Cookie` to identify which security product is in front of the site. Detects Cloudflare, Akamai, Imperva Incapsula, Sucuri, AWS CloudFront, AWS WAF, AWS ELB, F5 BIG-IP, F5 BIG-IP ASM, Fastly, Azure Front Door, Barracuda, Wallarm, StackPath, Google Frontend. Identifying the specific product matters because remediation differs completely per product — see "Recommendation playbooks" below.
+4. **Per-bot probes** — replays the request with each of 13 AI crawler user-agents (GPTBot, ChatGPT-User, ClaudeBot, anthropic-ai, PerplexityBot, Google-Extended, Applebot-Extended, GoogleBot, BingBot, CCBot, Bytespider, Meta-ExternalAgent, cohere-ai). For each bot the probe records HTTP status, body length, and content similarity to the baseline. A bot is considered blocked if any of:
+   - status is 403, 406, 429, or 503
+   - body matches Cloudflare challenge markers (the "200 OK with a disguised block page" case)
+   - body is non-trivially smaller AND content similarity to baseline is suspiciously low (silent content stripping)
+
+## Workflow
+
+Follow these steps when this skill triggers.
+
+### Step 1 — Run the probe
+
+Invoke the script and capture its JSON output:
+
+```bash
+python scripts/fetch_page.py <url> bots
+```
+
+The output is a single JSON object with this shape:
+
+```json
+{
+  "url": "https://example.com/",
+  "baseline": {"status": 200, "length": 523601, "used_playwright": true},
+  "js_challenge_detected": true,
+  "wafs_detected": [{"product": "Cloudflare", "evidence": "cf-ray header"}],
+  "probes": [
+    {"bot": "GPTBot", "status": 200, "length": 513540, "similarity": 0.85, "blocked": false, "block_reason": null},
+    {"bot": "GoogleBot", "status": 403, "length": 673193, "similarity": null, "blocked": true, "block_reason": "http_403"}
+  ],
+  "errors": []
+}
+```
+
+Parse this JSON in Bash with `python -c` or `jq`. Don't re-fetch the URL — the JSON is the source of truth.
+
+### Step 2 — Cross-reference declared policy
+
+Run the existing `robots` mode to get static `robots.txt` analysis:
+
+```bash
+python scripts/fetch_page.py <url> robots
+```
+
+Then walk every entry in `probes[]` from Step 1 and compare against the declared status from Step 2. The four interesting cases are:
+
+| Live result | Declared in robots.txt | Interpretation |
+|---|---|---|
+| Allowed | Allowed | Healthy. No action. |
+| **Blocked** | **Allowed** | **Critical mismatch.** Declared policy says the bot is welcome, but a WAF / bot management rule is overriding it. This is the #1 finding to surface — the user almost certainly didn't intend this. |
+| Allowed | Disallowed | Soft mismatch. Site is technically reachable but the bot is supposed to honour robots.txt. Worth mentioning. |
+| Blocked | Disallowed | Consistent. Likely intentional. No action unless the user wants to change policy. |
+
+The mismatch case (live blocked + declared allowed) is the most valuable finding this skill produces. It exists *only* because we're doing live probing — static analysis would have missed it entirely.
+
+### Step 3 — Score and verdict
+
+Compute a simple score from the probe results so the user has a single number to track across iterations. Recommended scoring (this is intentionally lightweight — `geo-technical` and `geo-audit` have richer scoring):
+
+- Start at 100
+- Subtract 10 for each blocked bot in `AI_SEARCH_BOTS` (GPTBot, ChatGPT-User, ClaudeBot, PerplexityBot, Google-Extended, Applebot-Extended, GoogleBot, BingBot)
+- Subtract 3 for each blocked training-only crawler (CCBot, Bytespider, Meta-ExternalAgent, cohere-ai, anthropic-ai)
+- Subtract 30 if `js_challenge_detected` is true and `baseline.used_playwright` is false (the site is invisible to non-browser clients and we couldn't even bypass it for the scan)
+- Floor at 0
+
+Then assign a verdict:
+
+| Score | Verdict |
+|---|---|
+| 90–100 | OPEN |
+| 70–89 | PARTIALLY BLOCKED |
+| 50–69 | MOSTLY BLOCKED |
+| 0–49 | BLOCKED |
+
+### Step 4 — Generate recommendations
+
+Recommendations should be concrete and product-specific. Use the WAF fingerprint from `wafs_detected` to give the user the exact dashboard path or config snippet for the product they're actually running.
+
+#### Recommendation playbooks
+
+**Cloudflare detected + bots blocked:**
+> Cloudflare is blocking [bot list]. Fix in the Cloudflare dashboard:
+> 1. Security → Bots → Configure Bot Management
+> 2. Set "Verified Bots" to **Allow** (this covers GPTBot, ClaudeBot, Googlebot, Bingbot via Cloudflare's verified bot directory)
+> 3. If using WAF Custom Rules, add an exception:
+>    - Expression: `(cf.client.bot) or (cf.verified_bot_category eq "AI Crawler")`
+>    - Action: Skip → All remaining custom rules
+> 4. If using Super Bot Fight Mode, set "Verified Bots" to Allow and only challenge "Likely Automated" / "Definitely Automated" categories.
+
+**Cloudflare JS challenge on baseline:**
+> Cloudflare is serving a JavaScript interstitial to all non-browser visitors. Non-browser HTTP clients — which is every AI crawler — cannot execute JavaScript and see the challenge page instead of your content. This makes the site invisible to AI search regardless of any robots.txt allowance. Fix in Cloudflare dashboard → Security → Bots → set Verified Bots to Allow so Cloudflare's verified bot directory bypasses the challenge automatically.
+
+**AWS WAF detected + bots blocked:**
+> AWS WAF is blocking [bot list]. Fix in the AWS Console:
+> 1. AWS WAF → Web ACLs → select your ACL → Rules
+> 2. Add a rule with a `ByteMatchStatement` matching `User-Agent` contains the bot name (e.g. `GPTBot`)
+> 3. Action: **Allow**
+> 4. Place the rule above any blanket bot-blocking rule so it takes precedence.
+
+**Imperva Incapsula detected + bots blocked:**
+> Imperva Cloud WAF is blocking [bot list]. Fix in the Cloud WAF console:
+> 1. Site Settings → Bot Access Control
+> 2. Add the bot's User-Agent to the **Good Bot Allowlist**
+> 3. Save and propagate (changes take ~5 minutes)
+
+**Sucuri detected + bots blocked:**
+> Sucuri Firewall is blocking [bot list]. Fix:
+> 1. Sucuri dashboard → Settings → Whitelist
+> 2. Add the bot User-Agent strings under "Whitelist by User-Agent"
+
+**Akamai detected + bots blocked:**
+> Akamai Bot Manager is blocking [bot list]. Fix:
+> 1. Akamai Control Center → Security → Bot Manager → Custom Bot Categories
+> 2. Add the AI search bots to a custom category with action "Allow"
+> 3. Or set the relevant Akamai-managed AI bot categories to "Allow"
+
+**No WAF detected, bots blocked:**
+> A custom server / application rule is blocking [bot list]. Look in:
+> - `.htaccess` (Apache) — search for `BrowserMatch` or `RewriteCond %{HTTP_USER_AGENT}`
+> - `nginx.conf` (Nginx) — search for `if ($http_user_agent ...`
+> - Application middleware — many CMS plugins (Wordfence, MalCare) maintain bot blocklists
+
+**Googlebot is blocked (any product):**
+> Surface this **separately and prominently**, even if the user only asked about AI bots. A Googlebot 403 affects regular Google Search indexing, not just AI search — the site may be deindexing without anyone noticing. This is almost always unintentional.
+
+### Step 5 — Format the output
+
+Present the findings as:
+
+1. A one-line headline: `Score: X/100 — VERDICT`
+2. The WAF/CDN line (e.g. `Behind: Cloudflare (cf-ray header)`)
+3. A compact table of bots and their results, with `✓` for allowed and `✗` for blocked
+4. The "declared vs actual" mismatch section if any mismatches exist
+5. Prioritised recommendations (Critical → High → Medium)
+6. Suggested next action for the user (e.g. "Want me to draft the Cloudflare WAF rule?", or "Run again after the fix to verify")
+
+Keep it scannable. The user is iterating — they want to see the score change, find the new findings, and act, not read prose.
+
+## Edge cases to mention to the user
+
+- **Bot verification by IP** — some sites correctly reject fake bot user-agents from residential IPs while letting the real Googlebot through via reverse-DNS verification. This probe always comes from the user's machine, so a 403 to "Googlebot" doesn't *definitively* prove the real Googlebot is blocked. It strongly suggests UA-based rules they should audit, but mention this nuance when reporting Googlebot blocks specifically.
+- **Rate limiting vs bot blocking** — if the same bot returns 200 on one run and 429 on the next, the site may be rate-limiting rather than bot-blocking. The probe flags 429 as blocked, which is a reasonable simplification but worth mentioning if the pattern looks time-based.
+- **JS challenge baseline degradation** — if `js_challenge_detected` is true and `baseline.used_playwright` is false, the similarity-based block detection becomes unreliable (every response is being compared against a challenge page). Status-code detection still works, but warn the user that the report is best-effort.
+- **Identical responses across bots** — if every bot returns the same response (whether 200 or 403), it's likely UA-agnostic — either fully open or fully blocked at a layer that doesn't inspect User-Agent (IP-based, geo-based). Mention this so the user looks in the right place.
+
+## Re-running for iteration
+
+This skill is designed for the fix-and-retest loop. When the user reports making a change (e.g. "I added the Cloudflare rule"), simply re-invoke `python scripts/fetch_page.py <url> bots` and diff against the previous run. The score is directly comparable. The fastest user-facing summary is: "Score went from 50 to 90. GPTBot, ClaudeBot, Googlebot all now returning 200. Cloudflare WAF rule is working."

--- a/skills/geo-technical/SKILL.md
+++ b/skills/geo-technical/SKILL.md
@@ -56,6 +56,31 @@ Check robots.txt for directives targeting these AI crawlers:
 
 **Important nuance**: Blocking Google-Extended does NOT block Googlebot. Google-Extended only controls AI training data usage, not search indexing. However, blocking Google-Extended may reduce presence in AI Overviews. Recommend allowing Google-Extended unless there is a specific data licensing concern.
 
+#### 1.2.1 Live AI Crawler Reachability (verify declared policy)
+
+`robots.txt` declares *intent*. A site can have a permissive `robots.txt` while a Cloudflare bot management rule, an AWS WAF custom rule, or an Imperva allowlist silently returns `HTTP 403` to GPTBot, ClaudeBot, and Googlebot — the declared policy looks fine, but AI search products see nothing. This step closes that gap by replaying the request as each AI crawler and observing what actually comes back.
+
+Run the live probe (same `fetch_page.py` script used elsewhere in this audit, in `bots` mode):
+
+```bash
+python scripts/fetch_page.py <url> bots
+```
+
+The probe fetches a Chrome baseline (with a Playwright fallback if Cloudflare serves a JS challenge), fingerprints the WAF/CDN in front of the site, then replays the request with 13 AI crawler user-agents and records HTTP status, body length, and content similarity to baseline. The output is a single JSON object with `baseline`, `js_challenge_detected`, `wafs_detected`, and a `probes[]` array.
+
+**How to use the result in this audit:**
+
+1. Walk every `probes[]` entry and compare against the declared `robots.txt` status from 1.2. The critical case is **live blocked + declared allowed** — this is the #1 finding to surface. It exists *only* because of live probing; static `robots.txt` analysis would have missed it.
+2. If `js_challenge_detected` is `true` and `baseline.used_playwright` is `false`, the site is invisible to every non-browser HTTP client (which is every AI crawler, regardless of robots.txt). Treat this as a critical technical failure.
+3. Use `wafs_detected` to make remediation product-specific. Cloudflare, AWS WAF, Imperva, Sucuri, and Akamai each fix this in completely different consoles — naming the actual product turns "your bots are blocked" into an actionable next step.
+4. **Googlebot blocked is its own emergency.** Surface it separately and prominently even if the user only asked about AI bots — a Googlebot 403 affects regular Google Search indexing, not just AI search, and the site may be deindexing without anyone noticing.
+
+**Scoring impact:** the live probe determines the *actual* score for 1.2. If `robots.txt` declares an AI crawler is allowed but the live probe shows it blocked, score that crawler as blocked — declared intent doesn't earn points if the bot can't reach the page.
+
+**Caveat to mention in the report:** the probe runs from the auditor's machine, so a 403 to "Googlebot" strongly suggests UA-based rules but doesn't *definitively* prove the real Googlebot (which Cloudflare/Akamai verify by reverse-DNS) is blocked. Note this nuance when reporting Googlebot blocks.
+
+For users who want to invoke the live probe directly outside a full audit (e.g. iterating on a Cloudflare WAF fix and re-checking after each change), point them at the standalone `geo-botaccess` skill, which wraps the same script with a fix-and-retest workflow.
+
 ### 1.3 XML Sitemaps
 - Fetch sitemap (check robots.txt for location, or try `/sitemap.xml`, `/sitemap_index.xml`)
 - Validate XML syntax

--- a/tests/test_fetch_page_bots.py
+++ b/tests/test_fetch_page_bots.py
@@ -1,0 +1,380 @@
+"""
+Tests for the live AI crawler probe added to fetch_page.py.
+
+Covers:
+  - WAF/CDN fingerprinting (detect_waf) per product family
+  - Cloudflare challenge-page detection (is_challenge_page)
+  - Content similarity helper (_content_similarity)
+  - probe_ai_crawlers() block-detection rules:
+      * HTTP 403 / 406 / 429 / 503
+      * 200 OK with a disguised challenge body
+      * Healthy 200 with high similarity to baseline (allowed)
+      * Silent content stripping (low similarity + small body)
+  - probe_ai_crawlers() probes every bot in AI_CRAWLERS
+
+Mocking style mirrors test_fetch_page_ssr.py — patch
+``fetch_page.requests.get`` with a MagicMock and feed responses via
+``side_effect`` so each successive call returns the next mock.
+"""
+
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from fetch_page import (  # noqa: E402
+    AI_CRAWLERS,
+    detect_waf,
+    is_challenge_page,
+    _content_similarity,
+    probe_ai_crawlers,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _resp(status=200, text="<html><body>baseline content</body></html>",
+          headers=None):
+    """Build a minimal mock requests.Response for probe_ai_crawlers/detect_waf."""
+    mock = MagicMock()
+    mock.status_code = status
+    mock.text = text
+    mock.headers = headers or {}
+    mock.history = []
+    mock.url = "http://example.com/"
+    return mock
+
+
+# A reasonably long baseline body so similarity comparisons are meaningful
+# and length ratios behave like real-world pages.
+BASELINE_HTML = (
+    "<!DOCTYPE html><html><head><title>Example</title></head>"
+    "<body><h1>Example article</h1>"
+    + ("<p>Real server-rendered content paragraph with plenty of words. </p>" * 40)
+    + "</body></html>"
+)
+
+
+# ---------------------------------------------------------------------------
+# detect_waf — fingerprinting per product
+# ---------------------------------------------------------------------------
+
+class TestDetectWaf:
+    def test_cloudflare_via_cf_ray_header(self):
+        r = _resp(headers={"CF-Ray": "abc123-LHR", "Server": "cloudflare"})
+        products = [d["product"] for d in detect_waf(r)]
+        assert "Cloudflare" in products
+
+    def test_cloudflare_via_cookie(self):
+        r = _resp(headers={"Set-Cookie": "__cf_bm=xyz; Path=/"})
+        assert "Cloudflare" in [d["product"] for d in detect_waf(r)]
+
+    def test_aws_cloudfront(self):
+        r = _resp(headers={"X-Amz-Cf-Id": "abc"})
+        assert "AWS CloudFront" in [d["product"] for d in detect_waf(r)]
+
+    def test_aws_waf(self):
+        r = _resp(headers={"x-amzn-waf-action": "block"})
+        assert "AWS WAF" in [d["product"] for d in detect_waf(r)]
+
+    def test_akamai_via_server(self):
+        r = _resp(headers={"Server": "AkamaiGHost"})
+        assert "Akamai" in [d["product"] for d in detect_waf(r)]
+
+    def test_akamai_via_x_akamai_header(self):
+        r = _resp(headers={"X-Akamai-Transformed": "9 -"})
+        assert "Akamai" in [d["product"] for d in detect_waf(r)]
+
+    def test_imperva_via_x_iinfo(self):
+        r = _resp(headers={"X-Iinfo": "1-12345-12345"})
+        assert "Imperva Incapsula" in [d["product"] for d in detect_waf(r)]
+
+    def test_imperva_via_cookie(self):
+        r = _resp(headers={"Set-Cookie": "incap_ses_123_456=abc"})
+        assert "Imperva Incapsula" in [d["product"] for d in detect_waf(r)]
+
+    def test_sucuri(self):
+        r = _resp(headers={"Server": "Sucuri/Cloudproxy", "X-Sucuri-ID": "13"})
+        assert "Sucuri" in [d["product"] for d in detect_waf(r)]
+
+    def test_f5_bigip_via_cookie(self):
+        r = _resp(headers={"Set-Cookie": "BIGipServerpool_app=12345.6789.0000"})
+        assert "F5 BIG-IP" in [d["product"] for d in detect_waf(r)]
+
+    def test_fastly(self):
+        r = _resp(headers={"X-Fastly-Request-Id": "abc"})
+        assert "Fastly" in [d["product"] for d in detect_waf(r)]
+
+    def test_azure_front_door(self):
+        r = _resp(headers={"X-Azure-Ref": "0xyz"})
+        assert "Azure Front Door" in [d["product"] for d in detect_waf(r)]
+
+    def test_no_waf(self):
+        r = _resp(headers={"Server": "nginx/1.21.0"})
+        assert detect_waf(r) == []
+
+    def test_stacked_products_returned_together(self):
+        r = _resp(headers={
+            "CF-Ray": "abc",
+            "X-Amz-Cf-Id": "def",
+            "Server": "cloudflare",
+        })
+        products = [d["product"] for d in detect_waf(r)]
+        assert "Cloudflare" in products
+        assert "AWS CloudFront" in products
+
+    def test_dedupes_same_product(self):
+        # Multiple Cloudflare predicates would all match — detect_waf must
+        # only report the product once.
+        r = _resp(headers={
+            "CF-Ray": "abc",
+            "Server": "cloudflare",
+            "Set-Cookie": "__cf_bm=xyz",
+        })
+        products = [d["product"] for d in detect_waf(r)]
+        assert products.count("Cloudflare") == 1
+
+    def test_broken_predicate_does_not_break_scan(self):
+        # response.headers raising on iteration shouldn't kill detection.
+        r = MagicMock()
+        r.headers = {"Server": "cloudflare"}
+        # Should still return Cloudflare via the server-header predicate.
+        assert "Cloudflare" in [d["product"] for d in detect_waf(r)]
+
+
+# ---------------------------------------------------------------------------
+# is_challenge_page
+# ---------------------------------------------------------------------------
+
+class TestIsChallengePage:
+    def test_403_with_cf_marker(self):
+        assert is_challenge_page("<html>cf-challenge ray id 123</html>", 403)
+
+    def test_503_with_just_a_moment(self):
+        assert is_challenge_page("<html>Just a moment...</html>", 503)
+
+    def test_200_with_turnstile_marker(self):
+        assert is_challenge_page("<html>cf-turnstile widget</html>", 200)
+
+    def test_200_clean_page_not_challenge(self):
+        assert not is_challenge_page(BASELINE_HTML, 200)
+
+    def test_403_cloudflare_branded_error(self):
+        assert is_challenge_page("<html>Cloudflare error page</html>", 403)
+
+
+# ---------------------------------------------------------------------------
+# _content_similarity
+# ---------------------------------------------------------------------------
+
+class TestContentSimilarity:
+    def test_identical_pages(self):
+        assert _content_similarity(BASELINE_HTML, BASELINE_HTML) == 1.0
+
+    def test_completely_different_pages(self):
+        assert _content_similarity(BASELINE_HTML, "<html>nothing</html>") < 0.3
+
+    def test_handles_empty_strings(self):
+        # Empty vs empty: SequenceMatcher returns 1.0; we just want no crash.
+        assert _content_similarity("", "") in (0.0, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# probe_ai_crawlers — end-to-end behaviour with mocked HTTP
+# ---------------------------------------------------------------------------
+
+class TestProbeAiCrawlersAllAllowed:
+    """Healthy site: baseline 200 + every bot returns the same body."""
+
+    def test_no_bots_blocked(self):
+        baseline = _resp(status=200, text=BASELINE_HTML, headers={})
+        bot_responses = [
+            _resp(status=200, text=BASELINE_HTML, headers={})
+            for _ in AI_CRAWLERS
+        ]
+        with patch("fetch_page.requests.get",
+                   side_effect=[baseline] + bot_responses):
+            result = probe_ai_crawlers("http://example.com/")
+
+        assert result["baseline"]["status"] == 200
+        assert result["js_challenge_detected"] is False
+        assert len(result["probes"]) == len(AI_CRAWLERS)
+        assert all(p["blocked"] is False for p in result["probes"])
+
+    def test_probes_every_bot_in_AI_CRAWLERS(self):
+        baseline = _resp(status=200, text=BASELINE_HTML)
+        bot_responses = [_resp(status=200, text=BASELINE_HTML)
+                         for _ in AI_CRAWLERS]
+        with patch("fetch_page.requests.get",
+                   side_effect=[baseline] + bot_responses):
+            result = probe_ai_crawlers("http://example.com/")
+
+        probed = {p["bot"] for p in result["probes"]}
+        assert probed == set(AI_CRAWLERS.keys())
+
+
+class TestProbeAiCrawlersBlockedByStatus:
+    """A bot that gets a 403/406/429/503 must be flagged."""
+
+    def _run_with_bot_status(self, status):
+        baseline = _resp(status=200, text=BASELINE_HTML)
+        # First bot (GPTBot) gets the bad status, the rest are 200.
+        bot_responses = []
+        for i, _ in enumerate(AI_CRAWLERS):
+            if i == 0:
+                bot_responses.append(_resp(status=status, text="blocked"))
+            else:
+                bot_responses.append(_resp(status=200, text=BASELINE_HTML))
+        with patch("fetch_page.requests.get",
+                   side_effect=[baseline] + bot_responses):
+            return probe_ai_crawlers("http://example.com/")
+
+    def test_403_flagged(self):
+        result = self._run_with_bot_status(403)
+        first = result["probes"][0]
+        assert first["blocked"] is True
+        assert first["block_reason"] == "http_403"
+
+    def test_406_flagged(self):
+        result = self._run_with_bot_status(406)
+        assert result["probes"][0]["block_reason"] == "http_406"
+
+    def test_429_flagged(self):
+        result = self._run_with_bot_status(429)
+        assert result["probes"][0]["block_reason"] == "http_429"
+
+    def test_503_flagged(self):
+        result = self._run_with_bot_status(503)
+        assert result["probes"][0]["block_reason"] == "http_503"
+
+    def test_other_bots_remain_allowed(self):
+        result = self._run_with_bot_status(403)
+        # All bots except the first (which we forced to 403) should be OK.
+        assert all(p["blocked"] is False for p in result["probes"][1:])
+
+
+class TestProbeAiCrawlersBlockedByChallengeBody:
+    """200 OK with a Cloudflare challenge body must be flagged."""
+
+    def test_challenge_body_with_200_status(self):
+        baseline = _resp(status=200, text=BASELINE_HTML)
+        challenge_body = "<html>Just a moment... cf-challenge ray id 1</html>"
+        bot_responses = []
+        for i, _ in enumerate(AI_CRAWLERS):
+            if i == 0:
+                bot_responses.append(_resp(status=200, text=challenge_body))
+            else:
+                bot_responses.append(_resp(status=200, text=BASELINE_HTML))
+        with patch("fetch_page.requests.get",
+                   side_effect=[baseline] + bot_responses):
+            result = probe_ai_crawlers("http://example.com/")
+
+        first = result["probes"][0]
+        assert first["blocked"] is True
+        assert first["block_reason"] == "challenge_page"
+
+
+class TestProbeAiCrawlersBlockedByContentStripping:
+    """A 200 with a much smaller, dissimilar body should be flagged."""
+
+    def test_low_similarity_and_small_body(self):
+        baseline = _resp(status=200, text=BASELINE_HTML)
+        stripped = "<html><body>nothing here</body></html>"
+        bot_responses = []
+        for i, _ in enumerate(AI_CRAWLERS):
+            if i == 0:
+                bot_responses.append(_resp(status=200, text=stripped))
+            else:
+                bot_responses.append(_resp(status=200, text=BASELINE_HTML))
+        with patch("fetch_page.requests.get",
+                   side_effect=[baseline] + bot_responses):
+            result = probe_ai_crawlers("http://example.com/")
+
+        first = result["probes"][0]
+        assert first["blocked"] is True
+        assert first["block_reason"] == "content_stripped"
+        assert first["similarity"] is not None and first["similarity"] < 0.4
+
+
+class TestProbeAiCrawlersWafFingerprintingIntegration:
+    """The probe should populate wafs_detected from the baseline response."""
+
+    def test_cloudflare_recorded_on_baseline(self):
+        baseline = _resp(
+            status=200,
+            text=BASELINE_HTML,
+            headers={"CF-Ray": "abc-LHR", "Server": "cloudflare"},
+        )
+        bot_responses = [_resp(status=200, text=BASELINE_HTML)
+                         for _ in AI_CRAWLERS]
+        with patch("fetch_page.requests.get",
+                   side_effect=[baseline] + bot_responses):
+            result = probe_ai_crawlers("http://example.com/")
+
+        products = [d["product"] for d in result["wafs_detected"]]
+        assert "Cloudflare" in products
+
+
+class TestProbeAiCrawlersJsChallengeDetection:
+    """If the baseline body looks like a Cloudflare challenge, flag it."""
+
+    def test_js_challenge_detected_on_baseline(self):
+        challenge = "<html>Just a moment... cf-challenge ray id 1</html>"
+        baseline = _resp(status=200, text=challenge)
+        # When the baseline is a challenge and Playwright isn't installed,
+        # the probe falls back to status/challenge-marker detection only.
+        bot_responses = [_resp(status=200, text=BASELINE_HTML)
+                         for _ in AI_CRAWLERS]
+        with patch("fetch_page.requests.get",
+                   side_effect=[baseline] + bot_responses), \
+             patch("fetch_page._playwright_baseline", return_value=None):
+            result = probe_ai_crawlers("http://example.com/")
+
+        assert result["js_challenge_detected"] is True
+        assert result["baseline"]["used_playwright"] is False
+
+    def test_playwright_fallback_used_when_available(self):
+        challenge = "<html>Just a moment... cf-challenge ray id 1</html>"
+        baseline = _resp(status=200, text=challenge)
+        bot_responses = [_resp(status=200, text=BASELINE_HTML)
+                         for _ in AI_CRAWLERS]
+        with patch("fetch_page.requests.get",
+                   side_effect=[baseline] + bot_responses), \
+             patch("fetch_page._playwright_baseline",
+                   return_value=(200, BASELINE_HTML)):
+            result = probe_ai_crawlers("http://example.com/")
+
+        assert result["js_challenge_detected"] is True
+        assert result["baseline"]["used_playwright"] is True
+        assert result["baseline"]["length"] == len(BASELINE_HTML)
+
+
+class TestProbeAiCrawlersErrorHandling:
+    """A baseline fetch failure should populate errors and return early."""
+
+    def test_baseline_failure_records_error(self):
+        with patch("fetch_page.requests.get",
+                   side_effect=Exception("connection refused")):
+            result = probe_ai_crawlers("http://example.com/")
+
+        assert result["probes"] == []
+        assert any("Baseline fetch failed" in e for e in result["errors"])
+
+    def test_per_bot_request_error_marks_blocked(self):
+        baseline = _resp(status=200, text=BASELINE_HTML)
+        responses = [baseline]
+        # Every bot raises — each should be flagged blocked with request_error.
+        for _ in AI_CRAWLERS:
+            responses.append(Exception("timeout"))
+        with patch("fetch_page.requests.get", side_effect=responses):
+            result = probe_ai_crawlers("http://example.com/")
+
+        assert len(result["probes"]) == len(AI_CRAWLERS)
+        assert all(p["blocked"] for p in result["probes"])
+        assert all(
+            p["block_reason"].startswith("request_error")
+            for p in result["probes"]
+        )


### PR DESCRIPTION
## Why

`geo-crawlers` and `geo-technical` currently read declared policy: they parse `robots.txt` and meta tags to figure out what a site *says* about AI crawlers. That's necessary but not sufficient. A site can have a permissive `robots.txt` while a Cloudflare bot management rule, an AWS WAF custom rule, or an Imperva allowlist silently returns `HTTP 403` to GPTBot, ClaudeBot, and Googlebot. The declared policy looks fine; the live reality is that AI search products see nothing.

This PR adds an empirical probe that closes that gap and surfaces declared-vs-actual mismatches as critical findings. Smoke-tested on a real Cloudflare-fronted site (zman.co.il) where it correctly detected GPTBot/ClaudeBot/PerplexityBot allowed but Googlebot/Bingbot/CCBot returning 403 — exactly the kind of misconfiguration static analysis misses.

## Design choices

A few principles guided the shape of the change, in case they're useful for review:

1. **Least intrusive — extend, don't duplicate.** `scripts/fetch_page.py` already had an unused `AI_CRAWLERS` dict and is already the single HTTP entry-point used by every audit skill. Rather than introduce a new script, this PR adds a `bots` mode alongside the existing `robots` / `llms` / `full` modes. One file to maintain, one error pattern, one JSON contract.

2. **No skill-to-skill coupling.** Both the new `geo-botaccess` skill and the updated `geo-technical` skill call the same `python scripts/fetch_page.py <url> bots` directly. The script is the contract; skills don't depend on each other.

3. **Graceful degradation.** Playwright is imported inside the helper that needs it and the function returns `None` on `ImportError`. The probe still works (status-code only) on minimal installs that don't have Playwright.

4. **Why a standalone `geo-botaccess` skill *and* a `geo-technical` integration.** Users iterating on a Cloudflare/WAF fix need a fast fix-and-retest loop — they don't want to run a full audit each time. The standalone skill exists for that workflow. The `geo-technical` integration ensures every full audit catches the gap even when the user didn't explicitly ask.

5. **WAF fingerprinting is not cosmetic.** Remediation differs completely per product: \"Allow GPTBot in Cloudflare\" is a different procedure (Security → Bots → Verified Bots → Allow) than \"Allow GPTBot in Imperva\" (Site Settings → Bot Access Control → Good Bot Allowlist) than AWS WAF (ByteMatchStatement on User-Agent). Fingerprinting the actual product turns \"your bots are blocked\" into an actionable next step with a specific dashboard path.

## What's in the PR

### `scripts/fetch_page.py` (+~600 lines)

- **`AI_CRAWLERS`** expanded from 5 to 13 bots, grouped by tier (AI search bots / traditional search / training-only) with comments explaining the grouping
- **`AI_SEARCH_BOTS`** set — used by downstream skills to weight findings (a 403 on GPTBot is critical; a 403 on CCBot may be intentional)
- **`CF_CHALLENGE_MARKERS`** — substrings that indicate a Cloudflare interstitial / challenge page rather than real content
- **`WAF_FINGERPRINTS`** — table of `(product, predicate, evidence)` triples covering Cloudflare, Akamai, Imperva Incapsula, Sucuri, AWS WAF/CloudFront/ELB, F5 BIG-IP/ASM, Fastly, Azure Front Door, Barracuda, Wallarm, StackPath, Google Frontend
- **`is_challenge_page(html, status_code)`** — bounded to first 8 KB so it's cheap on long articles
- **`detect_waf(response)`** — pure function over headers/cookies, walks the full table (multiple products legitimately stack), de-dupes by product, never short-circuits on a broken predicate
- **`_playwright_baseline(url)`** — headless Chromium fallback when Cloudflare serves a JS challenge to the baseline fetch; gracefully returns `None` if Playwright isn't installed
- **`_content_similarity(a, b)`** — `SequenceMatcher` ratio over the first 10 KB of two pages, used to catch silent content stripping (200 OK with a stripped body)
- **`probe_ai_crawlers(url)`** — main entry. Fetches a Chrome baseline → detects JS challenges and tries the Playwright fallback → fingerprints WAF/CDN → replays the request as each AI crawler → multi-signal block detection. Returns a single JSON object with `baseline`, `js_challenge_detected`, `wafs_detected`, `probes[]`, `errors[]`.
- **`__main__`** dispatch — adds `bots` mode and includes it in `full`

Block detection rules in `probe_ai_crawlers` are deliberately layered to reduce false positives:
1. Status code in (403, 406, 429, 503) → `http_<n>`
2. Body matches Cloudflare challenge markers → `challenge_page` (catches the \"200 OK with disguised block page\" case)
3. Body is non-trivially smaller AND content similarity to baseline is low → `content_stripped` (both signals required, since either alone has too many false positives — mobile-optimised pages, A/B tests, etc.)

### `skills/geo-botaccess/SKILL.md` (new)

Standalone skill for the iterative fix-and-retest workflow. Triggering phrases include \"Can ChatGPT read my site?\", \"Is GPTBot blocked?\", \"Is Cloudflare blocking AI bots?\", \"Re-check after I fixed the WAF rule\". Workflow:

1. Run `python scripts/fetch_page.py <url> bots`
2. Cross-reference with `python scripts/fetch_page.py <url> robots` and surface declared-vs-actual mismatches as critical
3. Score (start at 100, -10 per blocked AI search bot, -3 per blocked training crawler, -30 if JS challenge unfixable) → verdict (OPEN / PARTIALLY BLOCKED / MOSTLY BLOCKED / BLOCKED)
4. Generate product-specific recommendations using the WAF fingerprint — playbooks for Cloudflare, AWS WAF, Imperva, Sucuri, Akamai, no-WAF, and a special \"Googlebot is blocked\" callout (because it affects regular Google Search indexing, not just AI)
5. Format as scannable headline / table / recommendations

Includes edge cases (bot verification by IP, rate limiting vs blocking, JS challenge baseline degradation) and a \"re-running for iteration\" section explaining how to diff scores across runs.

### `skills/geo-technical/SKILL.md` (+~25 lines)

Adds subsection **1.2.1 Live AI Crawler Reachability** within Category 1 (Crawlability). Tells the technical-audit subagent to invoke the same `bots` mode as part of every full audit, walk every probe and compare against the declared `robots.txt` status from 1.2, and surface live-blocked + declared-allowed as the #1 finding. No new points added — the live probe determines the *actual* score for the existing 1.2 (declared intent doesn't earn points if the bot can't reach the page). Points readers at the standalone `geo-botaccess` skill for the fix-and-retest loop.

### `tests/test_fetch_page_bots.py` (new, 38 tests)

Mirrors the mocked-`requests` style of `test_fetch_page_ssr.py`. Coverage:

- **`detect_waf`** — Cloudflare via header, cookie, and stacked products; AWS CloudFront/WAF; Akamai via server and `x-akamai-*`; Imperva via `x-iinfo` and cookie; Sucuri; F5 BIG-IP via cookie; Fastly; Azure Front Door; no-WAF case; de-duping the same product across multiple matching predicates; broken-predicate isolation
- **`is_challenge_page`** — 403 with cf marker, 503 with \"Just a moment\", 200 with turnstile, clean page negative case, Cloudflare-branded 403
- **`_content_similarity`** — identical, completely different, empty strings
- **`probe_ai_crawlers`** — every bot allowed, all 13 bots probed, 403/406/429/503 each flagged with correct `block_reason`, other bots remain allowed, challenge body with 200 status flagged as `challenge_page`, low similarity + small body flagged as `content_stripped`, WAF fingerprinting populated from baseline, JS challenge detection + Playwright fallback (with and without), baseline failure records error and returns early, per-bot request errors marked with `request_error`

All 38 new tests pass. The existing 14 SSR tests still pass (52/52 total).

## Test plan

- [ ] Pull the branch and run `python -m pytest tests/ -q` — should report 52 passed
- [ ] Try the new mode against any Cloudflare-fronted site: `python scripts/fetch_page.py https://example.com bots | python -m json.tool`
- [ ] Verify the JSON includes `wafs_detected`, `js_challenge_detected`, and 13 entries in `probes[]`
- [ ] Optional: install Playwright (`pip install playwright && python -m playwright install chromium`) and re-run on a site with a JS challenge to verify the fallback engages and `baseline.used_playwright` flips to `true`
- [ ] Read through `skills/geo-botaccess/SKILL.md` and the new `1.2.1` section in `skills/geo-technical/SKILL.md` — see whether the explanations land
