### PR TITLE
Suffix report filenames with the audited domain slug

### DIFF
--- a/skills/geo-report-pdf/SKILL.md
+++ b/skills/geo-report-pdf/SKILL.md
@@ -21,6 +21,8 @@ This skill generates a professional, visually polished PDF report from GEO audit
 
 ## How to Generate a PDF Report
 
+In the steps below, `<DOMAIN-SLUG>` means the audited domain with `www.` stripped, dots replaced by hyphens, and uppercased to match the rest of the filename (e.g. `example.co.uk` → `EXAMPLE-CO-UK`). Suffixing the report filename with the slug keeps reports for multiple clients distinguishable in the same directory and visually consistent with the rest of the filename.
+
 ### Step 1: Collect Audit Data
 
 After running a full `/geo-audit`, collect all scores, findings, and recommendations into a JSON structure. The JSON data must follow this schema:
@@ -89,7 +91,7 @@ EOF
 Run the PDF generation script:
 
 ```bash
-python3 ~/.claude/skills/geo/scripts/generate_pdf_report.py /tmp/geo-audit-data.json GEO-REPORT-[brand].pdf
+python3 ~/.claude/skills/geo/scripts/generate_pdf_report.py /tmp/geo-audit-data.json GEO-REPORT-<DOMAIN-SLUG>.pdf
 ```
 
 The script will produce a professional PDF report with:
@@ -132,7 +134,7 @@ When the user runs this skill, follow this exact sequence:
 
 6. **Run the PDF generator**:
    ```bash
-   python3 ~/.claude/skills/geo/scripts/generate_pdf_report.py /tmp/geo-audit-data.json "GEO-REPORT-[brand_name].pdf"
+   python3 ~/.claude/skills/geo/scripts/generate_pdf_report.py /tmp/geo-audit-data.json "GEO-REPORT-<DOMAIN-SLUG>.pdf"
    ```
 
 7. **Report success** — Tell the user the PDF was generated, its location, and file size.

--- a/skills/geo-report/SKILL.md
+++ b/skills/geo-report/SKILL.md
@@ -392,7 +392,7 @@ Be conservative with estimates. State assumptions clearly. Never guarantee speci
 
 ## Output
 
-Generate **GEO-CLIENT-REPORT.md** using the complete template above, filled with actual audit data. The report should be:
+Generate **`GEO-CLIENT-REPORT-<DOMAIN-SLUG>.md`** using the complete template above, filled with actual audit data — where `<DOMAIN-SLUG>` is the audited domain with `www.` stripped, dots replaced by hyphens, and uppercased to match the rest of the filename (e.g. `example.co.uk` → `EXAMPLE-CO-UK`, so the file becomes `GEO-CLIENT-REPORT-EXAMPLE-CO-UK.md`). This keeps reports for multiple clients distinguishable in the same directory and visually consistent with the rest of the filename. The report should be:
 - 40-80 pages equivalent in detail (3,000-6,000 words)
 - Ready to send to a client without editing
 - Self-contained (no references to other report files — all relevant data is included)


### PR DESCRIPTION
## Summary

Both `geo-report` and `geo-report-pdf` currently write to a fixed filename (`GEO-CLIENT-REPORT.md` / `GEO-REPORT-[brand].pdf`). When a consultant runs audits for multiple clients in the same directory, each new report silently overwrites the previous one — or, in the PDF case, the `[brand]` placeholder gets filled in inconsistently.

This PR standardises both on `<filename>-<DOMAIN-SLUG>.<ext>`, where `<DOMAIN-SLUG>` is the audited domain with `www.` stripped, dots replaced by hyphens, and uppercased to match the rest of the filename.

Examples:
- `example.co.uk` → `GEO-CLIENT-REPORT-EXAMPLE-CO-UK.md` / `GEO-REPORT-EXAMPLE-CO-UK.pdf`
- `www.example.co.uk` → `GEO-CLIENT-REPORT-EXAMPLE-CO-UK.md`

Pure SKILL.md edits — no code changes, no script changes, no behaviour change beyond the filename.

## Test plan

- [ ] Run `/geo-report` against any URL — confirm the output filename ends with `-<DOMAIN-SLUG>.md`
- [ ] Run `/geo-report-pdf` — confirm the output filename ends with `-<DOMAIN-SLUG>.pdf`
- [ ] Run a second audit against a different domain in the same directory — confirm both reports coexist without overwriting

🤖 Generated with [Claude Code](https://claude.com/claude-code)