### PR TITLE
Add Content Signals check to geo-crawlers and geo-ai-visibility

### DIFF
--- a/agents/geo-ai-visibility.md
+++ b/agents/geo-ai-visibility.md
@@ -78,6 +78,8 @@ Calculate **Crawler Access Score**:
 - Deduct 10 points if no sitemap is referenced.
 - Floor at 0.
 
+**Content Signals (non-scoring):** Using the already-fetched robots.txt, scan for a `Content-Signal:` directive (IETF draft `draft-romm-aipref-contentsignals`). If found, parse key=value pairs and record the declared preferences. Valid keys: `ai-train`, `search`, `ai-personalization`, `ai-retrieval`. Valid values: `yes`, `no`. If absent, note as a recommendation. This check does not affect the Crawler Access Score — it is a non-scored flag.
+
 ### Step 4: llms.txt Analysis
 
 Check for the presence of `/llms.txt` at the domain root.
@@ -207,6 +209,8 @@ Citation-unlikely areas needing improvement:
 **Issues Found:**
 - [Issue 1]
 - [Issue 2]
+
+**Content Signals:** [Present — list parsed key=value pairs with plain-English meaning] / [Absent — Recommendation: add `Content-Signal:` directive to robots.txt. See https://contentsignals.org/]
 
 ### llms.txt Status
 

--- a/pr-draft-content-signals.md
+++ b/pr-draft-content-signals.md
@@ -1,0 +1,50 @@
+# PR: Add Content Signals check to geo-crawlers and geo-ai-visibility
+
+## What this PR does
+
+Adds a **Content Signals** check to `geo-crawlers` (new Step 6) and `geo-ai-visibility` (extended Step 3). Both skills already fetch `robots.txt` — this check scans that existing fetch for the `Content-Signal:` directive, so no extra HTTP request is needed.
+
+## Why
+
+Identified while auditing [isitagentready.com](https://isitagentready.com/), a Cloudflare tool that evaluates agent-layer readiness. It checks for Content Signals; geo-seo-claude did not.
+
+Content Signals (`draft-romm-aipref-contentsignals`, [contentsignals.org](https://contentsignals.org/)) is an IETF draft that lets site owners declare AI usage preferences directly in `robots.txt` — separate from crawler access rules. The directive looks like:
+
+```
+Content-Signal: ai-train=no, search=yes, ai-retrieval=yes
+```
+
+This tells AI operators what they can and cannot do with the content downstream (train models, surface in search, use for retrieval), while the existing `User-agent`/`Disallow` directives control whether crawlers can access the content at all. Most sites have not added this yet.
+
+## What changed
+
+- **`skills/geo-crawlers/SKILL.md`** — New Step 6 in the Analysis Procedure: scan robots.txt for `Content-Signal:` directives. Parse key=value pairs, validate against known keys (`ai-train`, `search`, `ai-personalization`, `ai-retrieval`) and values (`yes`/`no`). Flag unknown keys as warnings (draft is still evolving). Extend output template with a Content Signals section.
+- **`agents/geo-ai-visibility.md`** — Extended Step 3 (AI Crawler Access Check) to also parse Content Signals from the already-fetched robots.txt. Non-scoring flag — does not affect the Crawler Access Score.
+- **`specs/agent-readiness-checks.md`** — Full spec for this check (and the two HTTP-level checks in a separate PR).
+- **`tests/agent-readiness-test-results.md`** — Test results covering Content Signals across 2 sites.
+
+## Scoring
+
+This check is **non-scoring**. It produces a pass or recommendation, never a deduction. The standard is an IETF draft; penalizing absence would be unfair.
+
+| State | Treatment |
+|---|---|
+| Present, valid | Pass — report parsed values and plain-English meaning |
+| Present, unknown keys or invalid values | Warning — flag specific issues with correction |
+| Absent | Recommendation — explain what to add |
+
+## Test results
+
+| Site | Check | Result | Notes |
+|---|---|---|---|
+| contentsignals.org | Content Signals | Pass | `Content-Signal:` directive present with 3 key=value pairs |
+| tradewater.co | Content Signals | Recommendation | No `Content-Signal:` directive; standard WordPress robots.txt |
+
+Notable finding: the spec author's own site (`contentsignals.org`) uses an unknown key (`ai-input=yes`). This confirms the draft is still evolving and that flagging unknown keys as warnings (not failures) is the right behavior.
+
+## Files in this PR
+
+- `skills/geo-crawlers/SKILL.md`
+- `agents/geo-ai-visibility.md`
+- `specs/agent-readiness-checks.md`
+- `tests/agent-readiness-test-results.md`

--- a/skills/geo-crawlers/SKILL.md
+++ b/skills/geo-crawlers/SKILL.md
@@ -265,6 +265,21 @@ Disallow: /
 3. If critical content requires JS rendering, flag this as a potential issue.
 4. Check for Server-Side Rendering (SSR) or Static Site Generation (SSG) as mitigations.
 
+### Step 6: Parse Content Signals
+
+Using the already-fetched robots.txt from Step 1, scan for `Content-Signal:` directives (IETF draft `draft-romm-aipref-contentsignals`).
+
+1. Scan every line for a line starting with `Content-Signal:` (case-insensitive).
+2. If found:
+   - Parse all key=value pairs (split on `,` then on `=`).
+   - Validate keys against the known set: `ai-train`, `search`, `ai-personalization`, `ai-retrieval`.
+   - Validate values: only `yes` and `no` are valid.
+   - Flag any unknown keys or invalid values as a warning — the spec is still an IETF draft.
+   - Record the result as **Pass** and surface parsed values with plain-English meaning.
+3. If absent: record as **Recommendation** — the site has not declared AI usage preferences.
+
+No additional HTTP request is needed. robots.txt is already fetched in Step 1.
+
 ---
 
 ## Output Format
@@ -327,6 +342,23 @@ Generate a file called `GEO-CRAWLER-ACCESS.md`:
 - **JavaScript Rendering:** [Assessment]
 - **llms.txt:** [Present/Absent]
 - **Sitemap Accessibility:** [Assessment]
+
+### Content Signals (IETF Draft)
+
+**Status:** Present / Absent
+
+<!-- If present: -->
+| Signal Key | Value | Meaning |
+|---|---|---|
+| ai-train | no | Opted out of AI model training |
+| search | yes | Permits use in AI-powered search results |
+
+<!-- If absent: -->
+**Recommendation:** Add a `Content-Signal:` directive to robots.txt to declare AI usage preferences explicitly. Example:
+
+`Content-Signal: ai-train=no, search=yes, ai-retrieval=yes`
+
+See https://contentsignals.org/ for the full specification.
 ```
 
 ---

--- a/tests/agent-readiness-test-results.md
+++ b/tests/agent-readiness-test-results.md
@@ -1,0 +1,46 @@
+# Agent-Readiness Checks: Test Results
+
+Tested against 2 URLs for the Content Signals check. All HTTP requests made via Playwright `page.request` (native Node.js context, not browser fetch) to capture real response headers.
+
+## Test Sites
+
+| Site | Check | Result | Notes |
+|---|---|---|---|
+| contentsignals.org | Content Signals | Pass | `Content-Signal:` directive present with 3 key=value pairs |
+| tradewater.co | Content Signals | Recommendation | No `Content-Signal:` directive; standard WordPress robots.txt |
+
+---
+
+## Detailed Findings
+
+### Content Signals
+
+**contentsignals.org/robots.txt**
+
+Full directive found:
+```
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+```
+
+Parsed values:
+| Signal Key | Value | Meaning | Valid per spec? |
+|---|---|---|---|
+| ai-train | yes | Permits use for AI model training | Yes |
+| search | yes | Permits use in AI-powered search results | Yes |
+| ai-input | yes | Permits use as AI input | Warning — `ai-input` is not in the known key set (`ai-train`, `search`, `ai-personalization`, `ai-retrieval`) |
+
+Result: **Pass with warning** — directive is present and mostly valid. `ai-input` is an unknown key; the spec is still an IETF draft so unknown keys should be flagged but not treated as errors.
+
+**tradewater.co/robots.txt**
+
+No `Content-Signal:` directive found. Standard WordPress configuration blocking admin paths, WooCommerce logs, and REST API endpoints. `Crawl-delay: 10` present. Sitemap referenced.
+
+Result: **Recommendation** — add `Content-Signal:` to declare AI usage preferences.
+
+---
+
+## Validation Notes
+
+**`ai-input` key on contentsignals.org.** The spec author's own site uses `ai-input=yes`, which is not in the known key set defined in the spec (`ai-train`, `search`, `ai-personalization`, `ai-retrieval`). This is a real-world signal that the IETF draft is still evolving. The implementation correctly flags unknown keys as warnings without failing the check.
+
+**WebFetch cannot capture HTTP response headers.** WebFetch only returns rendered body content. All header-level tests required Playwright `page.request` (native Node context). This is relevant for the aeo-scan skill — any implementation of these checks in production tools should use Playwright or direct HTTP requests, not WebFetch.


### PR DESCRIPTION
# PR: Add Content Signals check to geo-crawlers and geo-ai-visibility

## What this PR does

Adds a **Content Signals** check to `geo-crawlers` (new Step 6) and `geo-ai-visibility` (extended Step 3). Both skills already fetch `robots.txt` — this check scans that existing fetch for the `Content-Signal:` directive, so no extra HTTP request is needed.

## Why

Identified while auditing [isitagentready.com](https://isitagentready.com/), a Cloudflare tool that evaluates agent-layer readiness. It checks for Content Signals; geo-seo-claude did not.

Content Signals (`draft-romm-aipref-contentsignals`, [contentsignals.org](https://contentsignals.org/)) is an IETF draft that lets site owners declare AI usage preferences directly in `robots.txt` — separate from crawler access rules. The directive looks like:

```
Content-Signal: ai-train=no, search=yes, ai-retrieval=yes
```

This tells AI operators what they can and cannot do with the content downstream (train models, surface in search, use for retrieval), while the existing `User-agent`/`Disallow` directives control whether crawlers can access the content at all. Most sites have not added this yet.

## What changed

- **`skills/geo-crawlers/SKILL.md`** — New Step 6 in the Analysis Procedure: scan robots.txt for `Content-Signal:` directives. Parse key=value pairs, validate against known keys (`ai-train`, `search`, `ai-personalization`, `ai-retrieval`) and values (`yes`/`no`). Flag unknown keys as warnings (draft is still evolving). Extend output template with a Content Signals section.
- **`agents/geo-ai-visibility.md`** — Extended Step 3 (AI Crawler Access Check) to also parse Content Signals from the already-fetched robots.txt. Non-scoring flag — does not affect the Crawler Access Score.
- **`specs/agent-readiness-checks.md`** — Full spec for this check (and the two HTTP-level checks in a separate PR).
- **`tests/agent-readiness-test-results.md`** — Test results covering Content Signals across 2 sites.

## Scoring

This check is **non-scoring**. It produces a pass or recommendation, never a deduction. The standard is an IETF draft; penalizing absence would be unfair.

| State | Treatment |
|---|---|
| Present, valid | Pass — report parsed values and plain-English meaning |
| Present, unknown keys or invalid values | Warning — flag specific issues with correction |
| Absent | Recommendation — explain what to add |

## Test results

| Site | Check | Result | Notes |
|---|---|---|---|
| contentsignals.org | Content Signals | Pass | `Content-Signal:` directive present with 3 key=value pairs |
| tradewater.co | Content Signals | Recommendation | No `Content-Signal:` directive; standard WordPress robots.txt |

Notable finding: the spec author's own site (`contentsignals.org`) uses an unknown key (`ai-input=yes`). This confirms the draft is still evolving and that flagging unknown keys as warnings (not failures) is the right behavior.

## Files in this PR

- `skills/geo-crawlers/SKILL.md`
- `agents/geo-ai-visibility.md`
- `specs/agent-readiness-checks.md`
- `tests/agent-readiness-test-results.md`