### PR TITLE
fix: correct broken skill reference geo-llms-txt -> geo-llmstxt

### DIFF
--- a/skills/geo-report/SKILL.md
+++ b/skills/geo-report/SKILL.md
@@ -20,7 +20,7 @@ This skill aggregates outputs from all GEO audit skills into a single, professio
    - `geo-schema` -> GEO-SCHEMA-REPORT.md
    - `geo-technical` -> GEO-TECHNICAL-AUDIT.md
    - `geo-content` -> GEO-CONTENT-ANALYSIS.md
-   - (Optional) `geo-llms-txt` -> llms.txt assessment
+   - (Optional) `geo-llmstxt` -> llms.txt assessment
    - (Optional) `geo-brand-mentions` -> brand authority data
 2. Collect all scores and findings
 3. Calculate the composite GEO Readiness Score


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`skills/geo-report/SKILL.md` line 23 references the optional input skill as `` `geo-llms-txt` `` (with an internal hyphen), but the actual installed skill directory is `skills/geo-llmstxt/` and its frontmatter `name` field is `geo-llmstxt` (no internal hyphen).

## Impact

When a user runs the report workflow, step 1 instructs them to use `geo-llms-txt` as the skill name. Since no skill by that name exists, the llms.txt assessment step silently produces no output and llms.txt data is omitted from the generated client report. Section 9 ("llms.txt Status") of the report will be missing or empty.

## Fix

One-character change on line 23: rename `` `geo-llms-txt` `` → `` `geo-llmstxt` `` to match the actual installed skill name.