### PR TITLE
fix: disable Flask debug mode by default in webapp entrypoint

### DIFF
--- a/scripts/webapp/app.py
+++ b/scripts/webapp/app.py
@@ -211,4 +211,5 @@ def download_pdf(pid):
 # ── Run ─────────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5050)
+    debug = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
+    app.run(debug=debug, port=5050)


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Medium)

`scripts/webapp/app.py` line 214 runs the Flask development server with `debug=True` hardcoded. The Werkzeug interactive debugger is a powerful code-execution tool intended only for local development; when `debug=True` is active and the port is reachable, the debugger PIN can be bypassed or the debugger endpoint accessed directly, allowing arbitrary Python code execution on the host.

## Fix

Replace the hardcoded `debug=True` with an environment-variable gate:

```python
debug = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
app.run(debug=debug, port=5050)
```

`os` is already imported at the top of the file. This approach:
- Defaults to `debug=False` in any deployed or shared environment
- Lets developers opt in to debug mode locally via `FLASK_DEBUG=true python app.py`
- Requires no dependency changes