### PR TITLE
fix: validate URL scheme before fetching in fetch_page.py

### DIFF
--- a/scripts/fetch_page.py
+++ b/scripts/fetch_page.py
@@ -57,6 +57,11 @@ def fetch_page(url: str, timeout: int = 30) -> dict:
         "errors": [],
     }
 
+    parsed_url = urlparse(url)
+    if parsed_url.scheme not in ("http", "https"):
+        result["errors"].append(f"Unsupported URL scheme: {parsed_url.scheme!r}. Only http and https are allowed.")
+        return result
+
     try:
         response = requests.get(
             url,


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Medium)

`scripts/fetch_page.py` line 61 calls `requests.get(url, ...)` where `url` is passed in by the caller with no prior scheme validation. If this script is wrapped in an API endpoint or automation pipeline that passes user-controlled URLs, an attacker could supply `file://`, `ftp://`, or other non-HTTP schemes to probe internal network resources (Server-Side Request Forgery).

`urlparse` is already imported at line 10, so no new dependency is needed.

## Fix

Added a scheme check immediately before `requests.get()`. If the scheme is not `http` or `https`, the function returns early with an error entry in `result["errors"]` — consistent with how the existing code already surfaces errors — rather than raising an exception that callers might not expect.

```python
parsed_url = urlparse(url)
if parsed_url.scheme not in ("http", "https"):
    result["errors"].append(f"Unsupported URL scheme: {parsed_url.scheme!r}. Only http and https are allowed.")
    return result
```

This is a minimal, zero-dependency change that matches the existing error-reporting style in the function.