### PR TITLE
fix: validate crawled URLs stay within original domain in llmstxt_generator

### DIFF
--- a/scripts/llmstxt_generator.py
+++ b/scripts/llmstxt_generator.py
@@ -242,6 +242,11 @@ def generate_llmstxt(url: str, max_pages: int = 30) -> dict:
         if section_pages:
             full_lines.append(f"## {section}")
             for page in section_pages:
+                # Skip cross-origin URLs to prevent SSRF via redirect chains
+                if urlparse(page["url"]).netloc != parsed.netloc:
+                    full_lines.append(f"- [{page['title']}]({page['url']})")
+                    continue
+
                 # Try to fetch page description
                 try:
                     page_resp = requests.get(page["url"], headers=DEFAULT_HEADERS, timeout=10)


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Medium)

`scripts/llmstxt_generator.py` around line 247 iterates over `pages` collected during a site crawl and calls `requests.get(page["url"], ...)` to fetch descriptions for `llms-full.txt`. The URLs in `pages` come from links discovered on crawled pages, but there is no check that they belong to the original domain.

A malicious site could include redirect links pointing to internal-network addresses (e.g. `http://192.168.1.1/admin`). When the script follows the crawled link to fetch a description, it would make an unintended request to that internal address — a Server-Side Request Forgery (SSRF) attack via redirect chain.

## Fix

Added a `urlparse(page["url"]).netloc != parsed.netloc` check before the `requests.get()` call. Cross-origin entries are still written to the output (without a description) so no data is lost; only the outbound fetch is skipped.

```python
# Skip cross-origin URLs to prevent SSRF via redirect chains
if urlparse(page["url"]).netloc != parsed.netloc:
    full_lines.append(f"- [{page['title']}]({page['url']})")
    continue
```

Both `urlparse` and `parsed` are already available in the function scope.