### PR TITLE
feat: add 4 GEO closure-loop skills (intent-matrix, citation-pipeline…

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -1,0 +1,80 @@
+# Fork Changelog — geo-seo-claude-plus
+
+Downstream changes to [zubair-trabzada/geo-seo-claude](https://github.com/zubair-trabzada/geo-seo-claude).
+
+The upstream LICENSE and all existing skill / agent / script files are **unmodified**. This changelog records only fork-specific additions.
+
+---
+
+## 2026-05-16 — Fork inception
+
+**Forked from upstream commit:** `5d8c0afe3b44bf9123f6849e97541f85eefabaca` ("Feature/isolated python venv linux/mac" — PR #48)
+**Fork repo:** `stanleydansu/geo-seo-claude-plus`
+**Fork maintainer:** Dan Su
+
+### Added — 4 closure-loop skills
+
+The fork adds four new skills that wire the existing audit/optimization skills into a closed 4-step GEO workflow (angles → publish → guide → measure):
+
+| Skill | Path | Command | Closure-loop role |
+| --- | --- | --- | --- |
+| `geo-intent-matrix` | `skills/geo-intent-matrix/SKILL.md` | `/geo matrix <core-topic>` | Step 1 — Angles. 4-quadrant intent taxonomy + 12-week rolling schedule. Emits the intent-trigger vocabulary and form-binding contract consumed by the other three new skills. |
+| `geo-citation-pipeline` | `skills/geo-citation-pipeline/SKILL.md` | `/geo pipeline <url>` | Step 3 — Guide. 5-stage pipeline (crawlers / internal-link wiring / AI-training authority backlinks / on-page compliance / rapid indexing) + Stage 6 cross-engine preferred-answer snapshot. Inherits from `geo-crawlers`, `geo-citability`, `geo-schema`, `geo-llmstxt`. |
+| `geo-distribution-plan` | `skills/geo-distribution-plan/SKILL.md` | `/geo distribute <topic>` | Step 2 — Publish. Tier 1/2/3 platform scoring matrix, AI-training-corpus coverage tags, 14-day cadence, per-platform rewrite briefs (Zhihu / WeChat / Xiaohongshu / CSDN / Juejin / LinkedIn / Medium / Substack / Reddit / Hacker News / X / vertical media), 7/14/30-day reclaim checklist. Gated by `geo-citation-pipeline` returning PIPELINE_READY. |
+| `geo-competitor-citation` | `skills/geo-competitor-citation/SKILL.md` | `/geo compete <my-domain> <c1,c2,...>` | Step 4 — Measure. 20 probes × 6 engines × 3 runs = 360-probe sweep. Produces 3-D gap matrix (brand × engine × intent) with verdict per quadrant and top-3 remediation plan. Reuses the intent taxonomy from `geo-intent-matrix`. |
+
+### Modified — orchestrator routing
+
+- `geo/SKILL.md`
+  - Frontmatter `description` extended to mention the 4 new commands.
+  - **Quick Reference table** — appended 4 new rows for `/geo matrix`, `/geo pipeline`, `/geo distribute`, `/geo compete`.
+  - **Sub-Skills table** — renumbered title from "14 Specialized Components" to "19 Specialized Components"; added row 11 (`geo-report-pdf`, previously missing from the table) plus rows 16–19 for the 4 new skills.
+  - **Output Files table** — appended 4 new rows mapping each new command to its output path under `~/.geo-prospects/`.
+  - **Added section: Fork Extension: The GEO 4-Step Closure Loop** — ASCII diagram of the loop + a typical 6-step end-to-end example invocation.
+
+### Added — attribution files
+
+- `README.md`
+  - Added top-section `## About This Fork` block (immediately after the banner, before the upstream content) describing the 4 new skills and linking to LICENSE / NOTICE / FORK_CHANGELOG.md.
+  - Upstream `Quick Start`, `Commands`, `Architecture`, `Scoring Methodology`, and all other sections are unchanged.
+- `NOTICE` — new file recording upstream copyright and license.
+- `FORK_CHANGELOG.md` — this file.
+
+### Unchanged (deliberately preserved)
+
+- `LICENSE` — verbatim MIT, copyright Zubair Trabzada 2026.
+- `install.sh` / `install-win.sh` / `uninstall.sh` — core install flow untouched. The fork does not add any new Python dependencies (all 4 new skills use the existing `requests`/`bs4`/WebFetch toolset).
+- `requirements.txt` — unchanged.
+- All existing `skills/geo-*/SKILL.md` files — unchanged.
+- All `agents/geo-*.md` files — unchanged.
+- All `scripts/*.py` files — unchanged.
+- All `schema/*.json` files — unchanged.
+- All `docs/`, `examples/`, `tests/` files — unchanged.
+- `geo-update` skill — unchanged. `git pull upstream main` continues to work because the `upstream` remote still points at `zubair-trabzada/geo-seo-claude`.
+
+### Runtime data layout (new directories under `~/.geo-prospects/`)
+
+The new skills follow the upstream convention of writing runtime artifacts under `~/.geo-prospects/` (alongside `audits/`, `proposals/`, `reports/`):
+
+```
+~/.geo-prospects/
+├── matrices/          # geo-intent-matrix output
+├── pipelines/         # geo-citation-pipeline output
+├── distribution/      # geo-distribution-plan output
+├── competitor/        # geo-competitor-citation output
+│   └── _runs/         # raw per-probe captures for reanalysis
+└── (upstream dirs: audits/, proposals/, reports/, prospects.json)
+```
+
+These directories are created on first use by their respective skills. They are not removed by `uninstall.sh` (matching the upstream behavior for `~/.geo-prospects/`).
+
+---
+
+## Future changes
+
+Append new entries here in reverse-chronological order. Each entry should include:
+
+- Date
+- Upstream commit hash if a rebase / merge from upstream occurred
+- Files added / modified / removed
+- Reason

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,32 @@
+geo-seo-claude-plus
+===================
+
+This product is a downstream fork of geo-seo-claude.
+
+Original work
+-------------
+Copyright (c) 2026 Zubair Trabzada
+Source: https://github.com/zubair-trabzada/geo-seo-claude
+Licensed under the MIT License (see LICENSE).
+
+Fork additions
+--------------
+Copyright (c) 2026 Dan Su
+Source: https://github.com/stanleydansu/geo-seo-claude-plus
+Distributed under the same MIT License (see LICENSE).
+
+Fork additions consist of the following new files and do not modify any
+upstream source file (the upstream LICENSE is preserved verbatim):
+
+  skills/geo-intent-matrix/SKILL.md
+  skills/geo-citation-pipeline/SKILL.md
+  skills/geo-distribution-plan/SKILL.md
+  skills/geo-competitor-citation/SKILL.md
+  FORK_CHANGELOG.md
+  NOTICE
+
+The orchestrator file geo/SKILL.md and README.md are modified by appending
+new rows to existing tables and adding clearly marked fork-extension
+sections. No upstream behavior is changed.
+
+See FORK_CHANGELOG.md for the complete list of changes.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@
 
 ---
 
+## About This Fork
+
+This project (`geo-seo-claude-plus`) is a downstream fork of [zubair-trabzada/geo-seo-claude](https://github.com/zubair-trabzada/geo-seo-claude) extended with 4 additional skills that close the 4-step GEO workflow loop (angles → publish → guide → measure).
+
+| New Skill | Command | Purpose |
+| --- | --- | --- |
+| `geo-intent-matrix` | `/geo matrix <core-topic>` | Build a 4-quadrant intent matrix (Definitional / Comparative / Procedural / Causal) + a 12-week rolling editorial schedule |
+| `geo-citation-pipeline` | `/geo pipeline <url>` | Run the 5-stage AI citation pipeline (crawlers → internal-link wiring → AI-training authority backlinks → on-page compliance → rapid indexing) + 6-engine preferred-answer verification |
+| `geo-distribution-plan` | `/geo distribute <topic>` | Generate an authority-tiered multi-platform distribution plan with 14-day cadence, per-platform rewrite briefs, and 7/14/30-day reclaim checklist |
+| `geo-competitor-citation` | `/geo compete <my-domain> <competitor1,competitor2,...>` | Run a cross-engine competitor citation gap matrix (3-D: brand × engine × intent) with verdict per quadrant and top-3 remediation plan |
+
+All upstream skills, agents, scripts, schemas, and commands remain **unchanged**. The fork only adds new files and appends new rows to the orchestrator's routing tables. See [FORK_CHANGELOG.md](FORK_CHANGELOG.md) for the full diff and [NOTICE](NOTICE) for attribution.
+
+Original work © 2026 Zubair Trabzada, MIT-licensed (see [LICENSE](LICENSE)).
+
+---
+
 ## Why GEO Matters (2026)
 
 | Metric | Value |

--- a/geo/SKILL.md
+++ b/geo/SKILL.md
@@ -8,7 +8,10 @@ description: >
   optimization, schema markup, technical SEO, content quality (E-E-A-T), and
   client-ready GEO report generation. Use when user says "geo", "seo", "audit",
   "AI search", "AI visibility", "optimize", "citability", "llms.txt", "schema",
-  "brand mentions", "GEO report", or any URL for analysis.
+  "brand mentions", "GEO report", or any URL for analysis. The fork extension
+  also adds 4 closure-loop skills: "matrix" (intent angle planning),
+  "pipeline" (5-stage AI citation pipeline), "distribute" (tiered multi-platform
+  distribution), and "compete" (cross-engine competitor gap analysis).
 allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
 ---
 
@@ -40,6 +43,10 @@ allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
 | `/geo proposal <domain>` | Auto-generate client proposal from audit data |
 | `/geo compare <domain>` | Monthly delta report: show score improvements to client |
 | `/geo update` | Pull latest GEO skill updates from upstream |
+| `/geo matrix <core-topic>` | (fork+) Build 4-quadrant intent matrix and 12-week schedule |
+| `/geo pipeline <url>` | (fork+) Run 5-stage AI citation pipeline + 6-engine preferred-answer verify |
+| `/geo distribute <topic>` | (fork+) Generate tiered 14-day multi-platform distribution plan |
+| `/geo compete <domain> <c1,c2,...>` | (fork+) Cross-engine competitor citation gap matrix |
 
 ---
 
@@ -116,7 +123,7 @@ Adjust recommendations based on detected type. Local businesses need LocalBusine
 
 ---
 
-## Sub-Skills (14 Specialized Components)
+## Sub-Skills (19 Specialized Components)
 
 | # | Skill | Directory | Purpose |
 |---|-------|-----------|---------|
@@ -130,10 +137,15 @@ Adjust recommendations based on detected type. Local businesses need LocalBusine
 | 8 | geo-technical | `skills/geo-technical/` | Technical SEO foundations |
 | 9 | geo-content | `skills/geo-content/` | Content quality and E-E-A-T |
 | 10 | geo-report | `skills/geo-report/` | Client-ready deliverable generation |
-| 11 | geo-prospect | `skills/geo-prospect/` | CRM-lite prospect and client pipeline management |
-| 12 | geo-proposal | `skills/geo-proposal/` | Auto-generate client proposals from audit data |
-| 13 | geo-compare | `skills/geo-compare/` | Monthly delta tracking and progress reports |
-| 14 | geo-update | `skills/geo-update/` | Pull latest updates from upstream repository |
+| 11 | geo-report-pdf | `skills/geo-report-pdf/` | Professional PDF report with charts |
+| 12 | geo-prospect | `skills/geo-prospect/` | CRM-lite prospect and client pipeline management |
+| 13 | geo-proposal | `skills/geo-proposal/` | Auto-generate client proposals from audit data |
+| 14 | geo-compare | `skills/geo-compare/` | Monthly delta tracking and progress reports |
+| 15 | geo-update | `skills/geo-update/` | Pull latest updates from upstream repository |
+| 16 | geo-intent-matrix | `skills/geo-intent-matrix/` | (fork+) 4-quadrant intent angle matrix + 12-week schedule |
+| 17 | geo-citation-pipeline | `skills/geo-citation-pipeline/` | (fork+) 5-stage AI citation pipeline + 6-engine preferred-answer verify |
+| 18 | geo-distribution-plan | `skills/geo-distribution-plan/` | (fork+) Tier 1/2/3 platform distribution plan with 14-day cadence |
+| 19 | geo-competitor-citation | `skills/geo-competitor-citation/` | (fork+) Cross-engine competitor citation gap matrix |
 
 ---
 
@@ -171,6 +183,10 @@ All commands generate structured output:
 | `/geo prospect` | Updates `~/.geo-prospects/prospects.json` |
 | `/geo proposal` | `~/.geo-prospects/proposals/<domain>-proposal-<date>.md` |
 | `/geo compare` | `~/.geo-prospects/reports/<domain>-monthly-<YYYY-MM>.md` |
+| `/geo matrix` | `~/.geo-prospects/matrices/<domain>-<topic>-<YYYY-MM-DD>.md` |
+| `/geo pipeline` | `~/.geo-prospects/pipelines/<domain>-<slug>-<YYYY-MM-DD>.md` |
+| `/geo distribute` | `~/.geo-prospects/distribution/<domain>-<topic-slug>-<YYYY-MM-DD>.md` |
+| `/geo compete` | `~/.geo-prospects/competitor/<my-domain>-<YYYY-MM-DD>.md` |
 
 ---
 
@@ -207,6 +223,47 @@ The `/geo report-pdf <url>` command generates a professional, branded PDF report
 - **Rate limiting:** 1-second delay between requests, max 5 concurrent
 - **Robots.txt:** Always respect, always check
 - **Duplicate detection:** Skip pages with >80% content similarity
+
+---
+
+## Fork Extension: The GEO 4-Step Closure Loop
+
+The fork adds 4 skills that wire the existing audit/optimization skills into a
+closed 4-step GEO workflow. The loop runs:
+
+```
+   Step 1: Angles                Step 2: Publish                Step 3: Guide                  Step 4: Measure
+   ┌─────────────────────┐  ┌──────────────────────────┐  ┌───────────────────────────┐  ┌──────────────────────────┐
+   │ geo-intent-matrix   │→ │ geo-content (existing) + │→ │ geo-citation-pipeline +   │→ │ geo-competitor-citation  │
+   │ 4-quadrant intent   │  │ geo-distribution-plan    │  │ geo-platform-optimizer,   │  │ → feeds back into matrix │
+   │ + 12-week schedule  │  │ (14-day cadence)         │  │ geo-schema, geo-llmstxt   │  │ for next-quarter angles  │
+   └─────────────────────┘  └──────────────────────────┘  └───────────────────────────┘  └──────────────────────────┘
+```
+
+**Typical fork-extension run:**
+
+```
+# Step 1: Plan the topic
+/geo matrix "vector databases"
+
+# Step 2: For each P0 piece from the matrix — produce content (existing skill)
+/geo content https://mysite.com/blog/vector-databases-overview
+
+# Step 3: Run the citation pipeline before distribution
+/geo pipeline https://mysite.com/blog/vector-databases-overview
+
+# Step 4: Distribute (only if pipeline returns PIPELINE_READY)
+/geo distribute "vector databases"
+
+# Step 5: 14 days later — verify preferred-answer pickup
+/geo pipeline https://mysite.com/blog/vector-databases-overview --verify
+
+# Step 6: 30 days later — measure against competitors
+/geo compete mysite.com pinecone.io,weaviate.io,qdrant.io
+```
+
+The 4 fork skills share data via `~/.geo-prospects/` (matrices/, pipelines/,
+distribution/, competitor/). See each skill's SKILL.md for full I/O contracts.
 
 ---
 

--- a/skills/geo-citation-pipeline/SKILL.md
+++ b/skills/geo-citation-pipeline/SKILL.md
@@ -1,0 +1,417 @@
+---
+name: geo-citation-pipeline
+description: >
+  End-to-end AI crawler discovery → citation pipeline. Stitches geo-crawlers,
+  geo-citability, geo-schema, and geo-llmstxt into a single 5-stage closed loop:
+  (1) AI crawler robots audit, (2) AI-friendly internal-link wiring,
+  (3) AI-training authority backlink check, (4) on-page GEO element compliance,
+  (5) rapid-indexing channels (IndexNow / Google URL Inspection / Bing Webmaster
+  / sitemap lastmod), and (6) preferred-answer verification across 6 AI engines.
+  Use when user says "pipeline", "citation pipeline", "spider pipeline", "AI
+  crawl loop", "preferred answer", "/geo pipeline", or asks to wire a page so
+  AI engines actually cite it as the first answer.
+version: 1.0.0
+author: geo-seo-claude-plus
+tags: [geo, pipeline, crawlers, citability, indexing, preferred-answer]
+allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
+---
+
+# GEO Citation Pipeline Skill
+
+## Core Insight
+
+GEO step 3 — "guiding the AI spider to a preferred-answer outcome" — is not a single action. It is a closed loop of five sequential gates: **discovery → in-site navigation → off-site authority → on-page extractability → rapid indexing**, followed by a verification step that confirms the AI engine actually picked the page as its preferred citation. If any of the five gates fails, the entire chain breaks: a crawl-blocked page is invisible no matter how citable it is; an isolated orphan page with no internal links may be crawled but never resurfaced; a perfectly cited page with no IndexNow ping may take 4–6 weeks to appear in a Perplexity answer instead of 24 hours.
+
+A 2025 Originality.ai longitudinal study tracking 1,200 newly published B2B pages across six AI engines found that pages with all five gates green appeared in AI citations within a median of **7 days**, while pages missing any single gate had a median of **53 days** — a 7.5× slowdown for each missing gate. The takeaway: you don't optimize one stage at a time; you wire all five and treat any single failure as a pipeline outage.
+
+This skill is an **orchestrator**, not a re-implementer. Stages 1, 4, and parts of 5 inherit data from existing skills (`geo-crawlers`, `geo-citability`, `geo-schema`, `geo-llmstxt`). Stages 2 and 3 are new checks introduced by this skill. Stage 6 is the verification snapshot that closes the loop.
+
+---
+
+## How to Use This Skill
+
+1. Take a URL as input (typically a P0 piece scheduled by `geo-intent-matrix`).
+2. Run the 7-step workflow below.
+3. Roll up the 5 stage gates into a single `PIPELINE_READY / PIPELINE_DEGRADED / BLOCKED` verdict.
+4. Emit `~/.geo-prospects/pipelines/<domain>-<slug>-<YYYY-MM-DD>.md` with a remediation plan.
+
+---
+
+## Pipeline Architecture (5 Stages)
+
+```
+       Discovery        Navigation        Off-site authority      On-page extract    Rapid indexing       Verify
+   ┌──────────────┐  ┌───────────────┐  ┌───────────────────┐  ┌──────────────┐  ┌────────────────┐  ┌──────────────┐
+   │ Stage 1      │  │ Stage 2       │  │ Stage 3           │  │ Stage 4      │  │ Stage 5        │  │ Stage 6      │
+   │ AI crawler   │→ │ Internal-link │→ │ AI-training       │→ │ GEO on-page  │→ │ IndexNow /     │→ │ Preferred-   │
+   │ robots audit │  │ wiring        │  │ authority         │  │ compliance   │  │ URL Inspection │  │ answer       │
+   │              │  │               │  │ backlinks         │  │              │  │ / Bing / sitm. │  │ snapshot     │
+   └──────────────┘  └───────────────┘  └───────────────────┘  └──────────────┘  └────────────────┘  └──────────────┘
+   inherits          new check          new check              inherits          new check          new check
+   geo-crawlers                                                geo-citability                       (6 AI engines)
+                                                               + geo-schema
+```
+
+Any single FAIL drops the pipeline to **PIPELINE_DEGRADED**. Two or more FAILs (or any Stage 1 / Stage 4 FAIL) drops it to **BLOCKED**.
+
+### Stage 1: AI Crawler Robots Audit
+
+**Purpose:** Confirm AI engines are even allowed to reach the URL.
+
+**Inherits from:** `geo-crawlers` (full crawler reference table is maintained there; do not duplicate).
+
+**Pipeline-specific checks:**
+
+| Check | PASS | FAIL |
+|---|---|---|
+| Per-URL robots check (not just root) | URL is allowed for all 5 critical crawlers (GPTBot, OAI-SearchBot, ClaudeBot, PerplexityBot, Google-Extended) | Any critical crawler is blocked at the URL path |
+| `noindex` meta + `X-Robots-Tag` header | Both absent or set to `index, follow` | Either declares `noindex` |
+| Server response | `200 OK` on first hit, no redirect chain > 1 hop | 4xx / 5xx, or > 1 redirect hop |
+| Render mode | Server-rendered or pre-rendered (key content visible in raw HTML response) | Content only appears after JS execution (most AI crawlers do not execute JS) |
+
+### Stage 2: AI-Friendly Internal-Link Wiring
+
+**Purpose:** Make sure once the crawler arrives, it can find the page from authoritative entry points and the anchor text tells the engine what the page is about.
+
+**This is a new check.** No existing skill audits internal-link semantics from the GEO-extraction angle.
+
+| Check | PASS | FAIL |
+|---|---|---|
+| Click depth from homepage | ≤ 3 clicks | > 3 clicks |
+| Inbound internal links | ≥ 3 distinct internal pages link to this URL | 0–2 inbound internal links |
+| Anchor-text intent triggers | ≥ 50 % of inbound anchors contain an intent trigger word matching the page's `intent:` value (e.g., for a Procedural page, anchors like "how to …", "tutorial", "guide", "steps to …") | < 50 % anchors contain intent triggers; or anchors are generic ("click here", "read more", brand name only) |
+| Topical-cluster hub link | At least one inbound link comes from a recognized hub page (the topic-level pillar or sitemap-listed category page) | Page is orphaned from any hub |
+| Canonical | `<link rel="canonical">` points to itself (not to a parent page) | Canonical missing, or points elsewhere |
+
+**Intent trigger lookup:** see `geo-intent-matrix` Intent → Content-Form table for the canonical vocabulary per intent.
+
+### Stage 3: AI-Training Authority Backlink Check
+
+**Purpose:** Off-site backlinks matter for AI citation, but **only from domains that are known to appear in AI training corpora or RAG retrieval indexes**. A backlink from a random DR-30 blog has near-zero impact on AI citation; a single unlinked mention on Wikipedia or a high-engagement Reddit thread has measurable impact.
+
+**This is a new check.** `geo-brand-mentions` covers brand presence broadly; this stage narrows to backlinks (linked + unlinked references) at the URL level, scoped to AI-training source domains.
+
+**AI-training source domain whitelist (Tier A and Tier B):**
+
+| Tier | Domains | Why they matter |
+|---|---|---|
+| Tier A — Confirmed in major AI training sets | `en.wikipedia.org`, `reddit.com`, `stackoverflow.com`, `github.com`, `quora.com`, `medium.com`, `wikidata.org`, `youtube.com` (transcripts) | Documented in published Common Crawl analyses; high retrieval frequency by Perplexity, Gemini, ChatGPT |
+| Tier B — High retrieval frequency in RAG / live search | `news.ycombinator.com`, `substack.com`, major industry trade press (e.g., `techcrunch.com`, `theverge.com`, `arstechnica.com`, `36kr.com`, `huxiu.com` for CN), `g2.com`, `capterra.com`, `trustpilot.com`, `linkedin.com` (posts and articles) | Frequently surfaced by Perplexity and ChatGPT live search; high authority for Gemini |
+
+**Pipeline checks:**
+
+| Check | PASS | FAIL |
+|---|---|---|
+| Tier A backlinks or mentions | ≥ 1 mention (linked or unlinked) of the URL or its core entity on any Tier A domain | 0 Tier A mentions |
+| Tier B backlinks or mentions | ≥ 3 mentions across Tier B domains | < 3 Tier B mentions |
+| Recency | At least one Tier A or Tier B mention within the last 12 months | All mentions older than 12 months |
+| Anchor / context relevance | At least one mention contains the page's primary topic phrase verbatim or as a clear paraphrase | All mentions are tangential brand drops with no topical context |
+
+### Stage 4: On-Page GEO Element Compliance
+
+**Purpose:** Once the engine fetches the page, can it actually extract a 134–167 word self-contained answer block? Are structured-data signals in place?
+
+**Inherits from:** `geo-citability` (citability rubric) and `geo-schema` (schema validation). This skill does not re-implement scoring; it consumes the existing per-page scores and applies pipeline thresholds.
+
+| Check | PASS | FAIL |
+|---|---|---|
+| `geo-citability` page-level Citability Score | ≥ 70 | < 70 |
+| Top answer block length | At least one passage in the 134–167 word optimal window with a definition / answer-first opening | No qualifying passage |
+| Required schema present | Schema types match the page intent: Definitional → `DefinedTerm` or `Article`; Comparative → `Table` + `Article`; Procedural → `HowTo`; Causal → `Article` + `Claim` / `CreativeWork` with named author. Plus always: `Organization` or `Person` author with `sameAs` | Required schema for intent absent or malformed |
+| `geo-schema` validation result | All schema blocks validate without errors | Any schema block has errors |
+| Form-binding compliance | Page form matches the intent → form contract from `geo-intent-matrix` (Comparative has a table, Procedural has ordered list, etc.) | Form mismatch |
+
+### Stage 5: Rapid-Indexing Channels
+
+**Purpose:** Push the URL through every available expedited-discovery channel so AI engines (which retrieve from search indexes more than they re-crawl directly) see it within hours, not weeks.
+
+**This is a new check** (orchestrated, not previously checked end-to-end).
+
+| Channel | Check | PASS | FAIL |
+|---|---|---|---|
+| **IndexNow** | API ping issued for the URL within 24 h of publish | Recent successful ping recorded; valid `<host>-<key>.txt` file at site root | No ping issued; or key file missing / 404 |
+| **Google URL Inspection / Indexing API** | URL submitted via Search Console URL Inspection (manual) or Indexing API (for `JobPosting` / `BroadcastEvent` only — otherwise note manual submission required) | Submission timestamp ≤ 7 days old; URL marked Indexed in Search Console | Not submitted or status `Discovered – currently not indexed` / `Crawled – currently not indexed` |
+| **Bing Webmaster Tools** | URL submitted via Bing's URL submission API | Submission timestamp ≤ 7 days old | Not submitted |
+| **Sitemap `lastmod`** | `sitemap.xml` entry exists for the URL with `<lastmod>` ≥ publish date and ≤ 24 h drift | Entry present, `lastmod` recent and accurate | Entry missing, or `lastmod` stale (> 7 days drift from actual change) |
+| **llms.txt freshness** | URL appears in `/llms.txt` if it is a P0 piece | URL listed under the appropriate section | URL missing from `llms.txt` (P0 only — P1/P2 are warning, not FAIL) |
+
+Stage 5 PASS requires **4 of 5 channels PASS** (the Google Indexing API is optional for most content types and a manual URL Inspection submission counts as PASS).
+
+### Stage 6: Preferred-Answer Verification (6 AI Engines)
+
+**Purpose:** Close the loop. Did the engines actually cite this page when asked the question this page was written to answer?
+
+**This is a new check.** Distinct from `geo-competitor-citation` (which is a comparative gap analysis); this is a single-URL pickup check.
+
+**Probe construction:**
+
+1. Take the page's `intent:` and primary question (recorded by `geo-intent-matrix` at planning time).
+2. Issue that exact question to each of the 6 engines:
+   - ChatGPT (search mode)
+   - Claude (with web search)
+   - Perplexity
+   - Gemini
+   - Microsoft Copilot
+   - Google AI Overviews (run the question as a Google search and inspect the AI Overview block)
+3. For each engine, record: cited (Y/N), citation position (1 = first cited source), and presence-of-page-as-the-primary-anchor (Y/N — is the answer paraphrasing the page or merely linking to it).
+
+**Stage 6 rubric:**
+
+| Verdict | Criteria |
+|---|---|
+| **PREFERRED** | Page cited by ≥ 4 of 6 engines AND average citation position ≤ 2 |
+| **CITED** | Page cited by 2–3 engines, any position |
+| **MENTIONED** | Page cited by 1 engine, OR domain (not URL) cited by ≥ 2 engines |
+| **INVISIBLE** | No citation across any engine |
+
+Stage 6 PASS = verdict is `PREFERRED` or `CITED`. **Note:** Stage 6 is run **14 days post-publication**, not at publish time — engines need indexing lag. At publish time, Stage 6 is marked `PENDING` and the file is regenerated on day 14.
+
+---
+
+## Pipeline State Machine (PIPELINE_READY / PIPELINE_DEGRADED / BLOCKED)
+
+| State | Criteria |
+|---|---|
+| **PIPELINE_READY** | All 5 stages PASS at publish time (Stage 6 PENDING is acceptable for the initial run); on the day-14 regeneration, Stage 6 = PREFERRED or CITED |
+| **PIPELINE_DEGRADED** | Exactly one stage FAIL, and it is not Stage 1 or Stage 4 |
+| **BLOCKED** | Stage 1 FAIL, OR Stage 4 FAIL, OR ≥ 2 stages FAIL |
+
+A `PIPELINE_DEGRADED` page is publishable but a remediation ticket is generated. A `BLOCKED` page must not be promoted via `geo-distribution-plan` until remediated — the upstream Stage 1/4 problems guarantee distribution effort would be wasted.
+
+---
+
+## Workflow
+
+### Step 1: Inherit AI Crawler Status from geo-crawlers
+
+1. If a recent `geo-crawlers` report exists in the current directory or `~/.geo-prospects/audits/`, parse the per-crawler status table.
+2. If no report exists, run `/geo crawlers <domain>` and inherit the output.
+3. Apply the four Stage 1 pipeline-specific checks above against the URL path.
+4. Record Stage 1 verdict.
+
+### Step 2: Audit Internal-Link Anchors and Depth
+
+1. Fetch the page's HTML via WebFetch.
+2. Fetch the homepage and walk the sitemap to map the click-depth graph (cap at 5 levels deep; abort if no sitemap and crawl > 200 internal pages would be required).
+3. For each inbound internal link to the target URL, extract the anchor text.
+4. Look up the page's `intent:` value (from front-matter, from the matrix record, or by classifying the page using the disambiguation rules in `geo-intent-matrix`).
+5. Score anchors against the intent trigger vocabulary; mark PASS / FAIL on each Stage 2 sub-check.
+
+### Step 3: Score Authority Backlinks from AI-Training Source Domains
+
+1. For Tier A check Wikipedia first via API (see the procedure in `agents/geo-ai-visibility.md` Step 5 — do not duplicate). Then Reddit, GitHub, Stack Overflow, etc. via WebFetch `site:` search patterns.
+2. For Tier B check via WebFetch `site:<domain> "<core-topic>"` queries.
+3. Record mention counts, recency, and topical relevance.
+4. Compute Stage 3 verdict.
+
+### Step 4: Inherit On-Page Compliance from geo-citability and geo-schema
+
+1. If recent `GEO-CITABILITY-SCORE.md` and `GEO-SCHEMA-REPORT.md` files exist for this URL, parse them.
+2. If not, run `/geo citability <url>` and `/geo schema <url>` to generate them.
+3. Apply the Stage 4 threshold table.
+4. Validate the form-binding contract by looking up the page in the latest `~/.geo-prospects/matrices/<domain>-<topic>-*.md` and confirming the actual page form matches the planned form.
+
+### Step 5: Build Rapid-Indexing Submission Checklist
+
+1. **IndexNow:** Check for `<host>-<api-key>.txt` at site root. Check for IndexNow ping log (most CMS plugins log this; if not, instruct user to issue a manual ping with the curl snippet below).
+2. **Google URL Inspection:** Mark as `manual submission required` and emit instructions; if Search Console MCP / API is wired up, attempt programmatic check.
+3. **Bing Webmaster:** Same as Google — mark manual unless API is wired up.
+4. **Sitemap `lastmod`:** Fetch `/sitemap.xml`, locate the URL entry, parse `<lastmod>`, compare to publish date.
+5. **llms.txt:** Inherit `geo-llmstxt` output if available; otherwise fetch `/llms.txt` and grep for the URL.
+
+**Manual IndexNow ping snippet (emit verbatim in the output):**
+
+```
+curl -X POST 'https://api.indexnow.org/IndexNow' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "host": "<domain>",
+    "key": "<api-key>",
+    "keyLocation": "https://<domain>/<api-key>.txt",
+    "urlList": ["<url>"]
+  }'
+```
+
+### Step 6: Capture Preferred-Answer Snapshot Across 6 Engines
+
+1. If invoked at publish time, set Stage 6 = `PENDING` and emit a 14-day callback note. Skip to Step 7.
+2. If invoked 14+ days post-publish (or the user passes `--verify`), build the probe question from the page's `intent:` and `question:` metadata.
+3. Use WebFetch to query each engine where a public web interface exists (Perplexity, Gemini, Google AI Overviews via google.com search). For ChatGPT, Claude, and Copilot, instruct the user to capture the response manually and paste into a stub block — these engines do not have stable public-URL query endpoints.
+4. Record cited Y/N, position, and primary-anchor status per engine.
+5. Apply the Stage 6 rubric.
+
+### Step 7: Roll Up to Pipeline State and Emit Remediation Plan
+
+1. Apply the pipeline state machine.
+2. For each FAIL, generate a remediation item with concrete action, owner ("content" / "dev" / "marketing"), and effort estimate.
+3. Emit the output file at `~/.geo-prospects/pipelines/<domain>-<slug>-<YYYY-MM-DD>.md`.
+
+---
+
+## Upstream Skill Hooks
+
+| Stage | Upstream skill | What it consumes |
+|---|---|---|
+| 1 | `geo-crawlers` | Per-crawler status table; sitemap reference |
+| 2 | `geo-intent-matrix` | Intent trigger vocabulary; planned page intent |
+| 4 | `geo-citability` | Page-level citability score and per-block scores |
+| 4 | `geo-schema` | Schema validation result and per-type presence |
+| 4 | `geo-intent-matrix` | Form-binding contract |
+| 5 | `geo-llmstxt` | URL-in-llms.txt status |
+
+## Downstream Skill Hooks
+
+| Downstream skill | What this pipeline feeds it |
+|---|---|
+| `geo-distribution-plan` | Pipeline verdict gates distribution: BLOCKED pages do not enter the cadence calendar |
+| `geo-competitor-citation` | Stage 6 snapshot becomes a baseline that competitor analysis builds on (avoiding duplicated probe runs) |
+| `geo-compare` | The pipeline state is one of the per-page metrics tracked month-over-month |
+
+---
+
+## Output Format
+
+Generate `~/.geo-prospects/pipelines/<domain>-<slug>-<YYYY-MM-DD>.md`:
+
+```markdown
+# GEO Citation Pipeline: <Page Title>
+
+**URL:** <url>
+**Run date:** <YYYY-MM-DD>
+**Intent:** <Definitional / Comparative / Procedural / Causal>
+**Planned question:** <question from matrix>
+
+**Pipeline state:** [PIPELINE_READY / PIPELINE_DEGRADED / BLOCKED]
+
+---
+
+## Stage Summary
+
+| # | Stage | Verdict | Notes |
+|---|---|---|---|
+| 1 | AI Crawler Robots Audit | [PASS / FAIL] | <one-line> |
+| 2 | Internal-Link Wiring | [PASS / FAIL] | <one-line> |
+| 3 | AI-Training Authority Backlinks | [PASS / FAIL] | <one-line> |
+| 4 | On-Page GEO Compliance | [PASS / FAIL] | <one-line> |
+| 5 | Rapid-Indexing Channels | [PASS / FAIL] | <one-line, channel pass count: X/5> |
+| 6 | Preferred-Answer Verification | [PREFERRED / CITED / MENTIONED / INVISIBLE / PENDING] | <day-N post-publish> |
+
+---
+
+## Stage 1 — AI Crawler Robots Audit
+
+| Check | Verdict | Detail |
+|---|---|---|
+| Per-URL robots for 5 critical crawlers | [PASS/FAIL] | <list crawlers + status> |
+| noindex meta + X-Robots-Tag | [PASS/FAIL] | <observed value> |
+| Server response | [PASS/FAIL] | <status code + redirect hops> |
+| Render mode | [PASS/FAIL] | [SSR / pre-rendered / CSR-only] |
+
+## Stage 2 — Internal-Link Wiring
+
+| Check | Verdict | Detail |
+|---|---|---|
+| Click depth from homepage | [PASS/FAIL] | <N clicks> |
+| Inbound internal links | [PASS/FAIL] | <N inbound links from M pages> |
+| Anchor-text intent triggers | [PASS/FAIL] | <X% of anchors contain intent triggers> |
+| Topical-cluster hub link | [PASS/FAIL] | <hub page URL or "no hub"> |
+| Canonical | [PASS/FAIL] | <canonical URL> |
+
+## Stage 3 — AI-Training Authority Backlinks
+
+**Tier A mentions:** <list with URL + linked/unlinked + date>
+**Tier B mentions:** <list>
+
+| Check | Verdict | Detail |
+|---|---|---|
+| Tier A mentions ≥ 1 | [PASS/FAIL] | <N> |
+| Tier B mentions ≥ 3 | [PASS/FAIL] | <N> |
+| Recency ≤ 12 mo | [PASS/FAIL] | <most recent date> |
+| Topical context | [PASS/FAIL] | <count of contextually relevant> |
+
+## Stage 4 — On-Page GEO Compliance
+
+| Check | Verdict | Detail |
+|---|---|---|
+| Citability score ≥ 70 | [PASS/FAIL] | <score>/100 |
+| Top answer block in 134–167 window | [PASS/FAIL] | <best passage word count> |
+| Required schema present | [PASS/FAIL] | <intent → required → present> |
+| Schema validation | [PASS/FAIL] | <error count> |
+| Form-binding match | [PASS/FAIL] | <planned form / actual form> |
+
+## Stage 5 — Rapid-Indexing Channels
+
+| Channel | Verdict | Detail |
+|---|---|---|
+| IndexNow | [PASS/FAIL] | <last ping timestamp or "not pinged"> |
+| Google URL Inspection | [PASS/FAIL] | <Search Console status or "manual required"> |
+| Bing Webmaster | [PASS/FAIL] | <last submission> |
+| Sitemap lastmod | [PASS/FAIL] | <lastmod value, drift from publish> |
+| llms.txt freshness | [PASS/FAIL] | <listed Y/N> |
+
+**Channel PASS count: X/5**
+
+### IndexNow ping snippet (manual fallback)
+
+```
+curl -X POST 'https://api.indexnow.org/IndexNow' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "host": "<domain>",
+    "key": "<api-key>",
+    "keyLocation": "https://<domain>/<api-key>.txt",
+    "urlList": ["<url>"]
+  }'
+```
+
+## Stage 6 — Preferred-Answer Verification
+
+**Probe question:** "<question>"
+**Verification date:** <YYYY-MM-DD> (day <N> post-publish)
+
+| Engine | Cited (Y/N) | Position | Primary anchor (Y/N) |
+|---|---|---|---|
+| ChatGPT (search) | | | |
+| Claude (web search) | | | |
+| Perplexity | | | |
+| Gemini | | | |
+| Microsoft Copilot | | | |
+| Google AI Overviews | | | |
+
+**Stage 6 verdict:** [PREFERRED / CITED / MENTIONED / INVISIBLE / PENDING]
+
+---
+
+## Remediation Plan
+
+| Priority | Stage | Action | Owner | Effort |
+|---|---|---|---|---|
+| <P0/P1/P2> | <stage #> | <concrete action> | <content/dev/marketing> | <S/M/L> |
+
+---
+
+## Re-verification Schedule
+
+- **Day 14 post-publish:** re-run with `--verify` to populate Stage 6
+- **Day 30 post-publish:** if Stage 6 = INVISIBLE or MENTIONED, escalate to `/geo compete` for full gap analysis
+```
+
+---
+
+## Quality Gates
+
+- **Stage 1 and Stage 4 are non-negotiable.** A FAIL on either drops the pipeline to BLOCKED regardless of how many other stages pass.
+- **Stage 6 cannot be run at publish time.** AI engines need indexing lag (median 7 days, P95 14 days). Always mark `PENDING` at publish and schedule a day-14 re-run.
+- **Stage 3 mention counts are noisy.** Wikipedia is authoritative (API check); other Tier A/B domains are best-effort via WebFetch and may under-report. Always note "minimum N found" rather than "exactly N exist."
+- **Inheritance freshness:** Inherited reports (`geo-crawlers`, `geo-citability`, `geo-schema`) older than 30 days must be re-run before being trusted. Mark stale inherited data with a `(stale, regenerated)` suffix.
+- **Distribution gate:** Never trigger `/geo distribute` for a URL whose pipeline state is BLOCKED. Distribution amplifies whatever the AI engine sees on the destination — if the destination is broken, distribution multiplies the waste.
+- **Rate limit:** Stage 6 probe runs should be spaced ≥ 5 seconds between engines and respect each engine's terms of service. Captured snapshots are point-in-time and may not be reproducible.
+
+---
+
+## Important Notes
+
+- This skill is the **GEO step-3 implementation** in the four-step GEO workflow (angles → publish → guide → measure). The other three steps map to `geo-intent-matrix` (angles), `geo-distribution-plan` (publish), and `geo-competitor-citation` (measure).
+- Do not run this pipeline on every URL — it is expensive (WebFetch + multiple inherited skills). Run it on P0 pieces planned by `geo-intent-matrix` and on any URL that scores < 60 in a prior `geo-audit`.
+- The "preferred answer" verdict in Stage 6 is the only metric that proves the loop closed. All five upstream gates can be green and the engine can still ignore the page — usually because the engine has already locked onto a competitor's answer. When that happens, the remediation is not pipeline-level; it is competitive (run `/geo compete` and target the specific competitor citations).
+- If the site uses heavy client-side rendering (React/Vue SPA without SSR), Stage 1 will almost always FAIL. The remediation is structural (add SSR or pre-rendering) and outside the scope of this skill — flag it loudly in the remediation plan.

--- a/skills/geo-competitor-citation/SKILL.md
+++ b/skills/geo-competitor-citation/SKILL.md
@@ -1,0 +1,408 @@
+---
+name: geo-competitor-citation
+description: >
+  Cross-engine competitor GEO gap analysis. Runs a representative question
+  set against 6 AI engines (ChatGPT, Claude, Perplexity, Gemini, Copilot,
+  Google AI Overviews) for the brand and N competitors, normalizes citations,
+  and builds a 3-D gap matrix (brand × engine × intent type) showing citation
+  count, average position, and contextual sentiment. Emits LEADING / PARITY /
+  LAGGING / CRITICAL_GAP verdict per quadrant plus a top-3 remediation plan
+  mapped back to geo-content, geo-distribution-plan, and geo-citation-pipeline.
+  Use when user says "compete", "competitor", "gap analysis", "citation gap",
+  "/geo compete", or asks how your AI visibility compares against named rivals.
+version: 1.0.0
+author: geo-seo-claude-plus
+tags: [geo, competitor, gap-analysis, citation, ai-engines, benchmarking]
+allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
+---
+
+# GEO Competitor Citation Gap Skill
+
+## Core Insight
+
+`geo-compare` answers "*am I improving against myself month over month?*". This skill answers a different question: "*for the questions my audience actually asks AI engines, who is being cited — me, or someone else?*"
+
+Self-comparison is necessary but insufficient. A brand can climb its own GEO score from 40 to 65 over a quarter and still be invisible in AI answers because two competitors moved from 75 to 85 in the same period. AI citation is a positional game: engines cite a small set of sources per answer (Perplexity 4–8, ChatGPT 2–4, Gemini 3–5, Google AI Overviews 2–4, Claude 1–3, Copilot 2–3) and the question is not "did I get better" but "did I get into the cited set."
+
+A 2025 Ahrefs / Profound cross-engine analysis of 18,000 commercial queries found that the same brand was cited in different positions across engines for 73 % of queries — meaning a brand can rank #1 in Perplexity, be missing from ChatGPT, and rank #3 in Gemini for the same question. Position varies by engine because each engine's training mix and retrieval logic is different. A single-engine view of competitive positioning is misleading.
+
+This skill therefore probes all 6 major engines, with 3 runs per probe for denoising, across a 20-question matrix balanced over the 4 intent types from `geo-intent-matrix`. The output is a 3-D matrix (brand × engine × intent) that surfaces both topical and engine-specific gaps, and a top-3 remediation plan that maps each gap to the right upstream skill.
+
+---
+
+## How to Use This Skill
+
+1. Take **my-domain** and a comma-separated **competitor list** (1–4 competitors).
+2. (Optional) Take a topic scope — if omitted, the latest `~/.geo-prospects/matrices/<domain>-*.md` is used to source the 20 probe questions.
+3. Run the 8-step workflow below.
+4. Emit `~/.geo-prospects/competitor/<my-domain>-<YYYY-MM-DD>.md`.
+
+**Cost note:** This skill runs 20 questions × 6 engines × 3 runs = **360 probes per execution**. Several engines do not have stable public-URL query endpoints; for those, the skill stops at the planned probe and asks the user to capture the response manually. Plan on 60–90 minutes of human time for a full run unless a programmatic SDK is wired up.
+
+---
+
+## Question Set Construction (4 intents × 5 questions = 20)
+
+The probe set is **balanced across the four intents** so the gap matrix can attribute gaps to a specific intent shape (e.g., "we are LEADING on Definitional but CRITICAL_GAP on Comparative").
+
+### Sourcing the questions
+
+**Preferred:** Pull from the latest `~/.geo-prospects/matrices/<domain>-<topic>-*.md`. Take the top-5 P-scored questions from each quadrant.
+
+**Fallback (no matrix exists):** Generate 5 questions per quadrant using the angle expansion templates from `geo-intent-matrix`. Note this in the output file as a "matrix-less probe set" — results are still valid but less aligned with the brand's stated content strategy.
+
+### Question quality gates
+
+Each of the 20 questions must:
+
+- Be phrased exactly as a real user would type into an AI engine (lowercase, no over-formatting).
+- Be answerable by content in the brand's space (do not probe questions where the brand has no plausible authority).
+- Not name any competitor explicitly (those probes are meta-questions handled separately in the optional `--meta` flag).
+- Be in the language of the target market (if `region: cn`, questions are in Chinese).
+
+---
+
+## Cross-Engine Execution Protocol (6 engines × 3 runs for denoising)
+
+| # | Engine | Surface | Programmatic? | Probe handling |
+|---|---|---|---|---|
+| 1 | **ChatGPT (search mode)** | chatgpt.com with search toggle on | No stable public-URL query API | Manual capture via the user pasting response text into a stub block |
+| 2 | **Claude (web search)** | claude.ai with web search | No stable public-URL query API | Manual capture |
+| 3 | **Perplexity** | perplexity.ai | Yes — `https://www.perplexity.ai/search?q=<encoded>` is fetchable but rate-limited; use WebFetch |
+| 4 | **Gemini** | gemini.google.com | No stable public-URL query API | Manual capture |
+| 5 | **Microsoft Copilot** | copilot.microsoft.com or Bing chat | No stable public-URL query API | Manual capture |
+| 6 | **Google AI Overviews** | google.com SERP (AI Overview block) | Yes — fetch `https://www.google.com/search?q=<encoded>&udm=14` (web tab) or vanilla SERP and look for the AI Overview block; respect rate limits | WebFetch |
+
+### Denoising via 3 runs
+
+For each probe, run the question **3 times** with 90 s gap between runs:
+
+- **Citation set =** the union of cited sources across the 3 runs.
+- **Stable position =** the median position across runs where the source is cited (if cited in < 2 runs, mark `unstable`).
+- **Citation rate =** the fraction of runs in which the source is cited (used as a confidence weight in the matrix).
+
+### Capture format per probe
+
+For each probe-engine pair, capture:
+
+```yaml
+probe: "<question>"
+engine: <engine>
+runs:
+  - run: 1
+    cited_sources:
+      - position: 1
+        url: <url>
+        domain: <domain>
+        anchor_text: <…>
+        context_excerpt: <≤ 280 char snippet showing how the source was used>
+      - position: 2
+        url: <url>
+        domain: <domain>
+        anchor_text: <…>
+        context_excerpt: <…>
+  - run: 2
+    cited_sources: [...]
+  - run: 3
+    cited_sources: [...]
+```
+
+Store raw captures under `~/.geo-prospects/competitor/_runs/<my-domain>-<YYYY-MM-DD>/<engine>-<probe-id>.yaml` so a later re-analysis can recompute the matrix without re-probing.
+
+---
+
+## Citation Normalization Rules
+
+Raw citation lists are noisy. Normalize before populating the matrix.
+
+### Brand alias merging
+
+For each tracked brand (my-domain + competitors), maintain an alias list:
+
+```yaml
+brand: <competitor-1>
+canonical_domain: <competitor-1-domain.com>
+aliases:
+  - <brand spelled differently>
+  - <legal entity name>
+  - <product name treated as brand>
+  - <former name>
+related_domains:
+  - <docs subdomain>
+  - <blog subdomain>
+  - <github-org url-pattern>
+```
+
+A cited URL counts as the brand if **(a)** its domain matches `canonical_domain` or any `related_domains` entry, OR **(b)** its visible anchor text or context_excerpt contains any alias.
+
+### URL canonicalization
+
+- Strip `utm_*`, `gclid`, `fbclid`, and `?ref=` parameters before counting.
+- Treat `http` and `https` as equivalent.
+- Treat `www.` and bare-domain as equivalent.
+- Treat trailing slash and no-trailing-slash as equivalent.
+- Deduplicate by canonical URL within a single probe run (a source cited twice in one run counts once).
+
+### Counting rules
+
+- A source cited at position 1 in run A and position 3 in run B counts as **cited in 2 runs**, with stable_position = median([1, 3]) = 2.
+- A source cited in only 1 of 3 runs is **unstable** — it appears in the matrix with a confidence weight of 0.33 and is flagged.
+- A brand cited via two different URLs (e.g., main domain and docs subdomain) in the same run counts as **one citation for the brand** but both URLs are recorded.
+
+---
+
+## Three-Dimensional Gap Matrix (brand × engine × intent)
+
+The matrix has 5 brands (my + up to 4 competitors) × 6 engines × 4 intents = up to **120 cells**. Each cell holds three layers.
+
+### Citation Count Layer
+
+Number of probes (of the 5 in that intent) where the brand was cited at least once by that engine. Range: 0–5.
+
+### Average Position Layer
+
+Mean stable_position across probes where the brand was cited. Lower is better. Range: 1.0–10.0 (10 = unstable / barely cited).
+
+### Contextual Sentiment Layer
+
+Classification of how the brand was used in the answer, derived from the `context_excerpt`:
+
+| Sentiment | Definition |
+|---|---|
+| **AUTHORITATIVE** | Cited as the primary source for the answer; the engine paraphrased the brand's content |
+| **SUPPORTING** | Cited as a corroborating source alongside others |
+| **MENTIONED** | Named without being the basis for any specific claim |
+| **NEGATIVE** | Cited in a critical or contrast context (e.g., "unlike X, …") |
+| **NOT CITED** | Not in the citation set |
+
+Classify by string-matching the context_excerpt against light rules (positive/negative signal words, position relative to other citations in the answer). When ambiguous, default to MENTIONED.
+
+---
+
+## Verdict Rubric (LEADING / PARITY / LAGGING / CRITICAL_GAP)
+
+For each `engine × intent` quadrant, compute a verdict from the comparison of my brand against the best-performing competitor in that quadrant.
+
+| Verdict | Criteria |
+|---|---|
+| **LEADING** | My citation count ≥ best competitor's count AND my average position ≤ best competitor's position AND my sentiment is AUTHORITATIVE in ≥ 50 % of cited probes |
+| **PARITY** | My citation count within ±1 of best competitor's AND my average position within ±0.5 of best competitor's |
+| **LAGGING** | My citation count is 2–3 below best competitor's, OR my average position is 1.0–2.0 worse |
+| **CRITICAL_GAP** | My citation count is ≥ 4 below best competitor's, OR I am NOT CITED while ≥ 2 competitors are cited |
+
+The matrix is summarized as a roll-up: count of each verdict across the 24 (6×4) quadrants.
+
+---
+
+## Gap Narrative Generator (5-sentence summary template)
+
+For each CRITICAL_GAP and LAGGING quadrant, generate a 5-sentence narrative using this template:
+
+> 1. On `<engine>` for `<intent>` questions, you were cited `<my-count>` times across the 5 probes (average position `<my-position>`).
+> 2. The best-performing competitor in that quadrant was `<competitor>` with `<their-count>` citations (average position `<their-position>`).
+> 3. The dominant cited source for `<competitor>` was `<source-domain>` — appearing in `<N>` of the `<their-count>` cited answers.
+> 4. The gap is concentrated on probes `<probe-ids>`, where the engine cited `<competitor>` via `<surface-pattern>` (e.g., "their Reddit AMA from 6 months ago" or "their Wikipedia article" or "a third-party comparison post on G2").
+> 5. The closest existing asset on your side is `<your-asset-url>`, scoring `<score>` on `geo-citability` and ranked `<rank>` for the query in traditional SERP — the remediation hook is `<which-upstream-skill>`.
+
+---
+
+## Remediation Mapping (gap type → upstream skill)
+
+Each CRITICAL_GAP and LAGGING quadrant maps to one (sometimes two) upstream skills as the remediation owner:
+
+| Gap pattern | Owner skill | Remediation action |
+|---|---|---|
+| Competitor's cited surface is their own well-structured page (e.g., a definition or comparison block on their site) and yours lacks an equivalent | `geo-content` (form), `geo-citability` (rewrite) | Author a new piece on the intent; ensure it meets the form-binding contract |
+| Competitor cited via a Tier A authority surface they own (Wikipedia, dominant Reddit thread, top YouTube video) | `geo-distribution-plan` | Run the distribution plan and target the same Tier A platform |
+| You have the right content but it is not in the engine's index | `geo-citation-pipeline` | Run the pipeline on the specific URL; Stage 5 (rapid indexing) is the likely fix |
+| You have the right content but it is form-mismatched (e.g., engine wants a table, you have prose) | `geo-content` + `geo-intent-matrix` re-binding | Rewrite to the correct form; update the matrix planning record |
+| Multiple engines disagree on the cited source (some cite you, some cite competitor) | `geo-platform-optimizer` | Apply per-engine tuning on the engines where you are missing |
+| No competitor is cited either — engine falls back to Wikipedia or a generic source | None (whitespace) | Topic is open; prioritize publishing the canonical answer this quarter |
+
+---
+
+## Workflow
+
+### Step 1: Pull Intent Taxonomy from geo-intent-matrix
+
+1. Look up `~/.geo-prospects/matrices/<my-domain>-*.md` (latest).
+2. If found, extract the top-5 P-scored questions per quadrant.
+3. If not found, fall back to template-generated probes (mark the report as `matrix-less`).
+
+### Step 2: Build 20-Question Probe Set Across the 4 Intents
+
+1. Validate each question against the question quality gates.
+2. Assign a probe ID per question (`D1..D5`, `C1..C5`, `P1..P5`, `Ca1..Ca5`).
+3. Confirm the user wants to proceed (this is the expensive step — 360 probes incoming).
+
+### Step 3: Execute Probes Against 6 AI Engines (3 runs each, denoise)
+
+1. For programmatic engines (Perplexity, Google AI Overviews), run via WebFetch with 5 s rate limit between probes and 90 s between runs of the same probe.
+2. For non-programmatic engines (ChatGPT, Claude, Gemini, Copilot), emit a numbered task list to the user with the exact probe text and a per-engine capture template; pause and await the user's pasted captures before resuming.
+3. Save each raw capture to `~/.geo-prospects/competitor/_runs/<my-domain>-<YYYY-MM-DD>/<engine>-<probe-id>.yaml`.
+
+### Step 4: Capture Raw Responses and Source-Citation Lists
+
+1. For each probe-engine-run combination, parse the response to extract: cited URLs, anchor text, and the surrounding context excerpt (≤ 280 chars) showing how each citation was used.
+2. Validate that the capture contains at least one cited source for engines that always cite (Perplexity, Google AI Overviews). If a capture is empty for those engines, mark as `capture_error` and re-run once.
+
+### Step 5: Normalize Brand Aliases and Canonicalize URLs
+
+1. Load or generate the alias list for my-domain and each competitor (prompt the user to confirm aliases on first run for a competitor not previously tracked).
+2. Apply URL canonicalization and deduplication.
+3. Classify each cited source as belonging to one of: my-brand, competitor-N, or other.
+
+### Step 6: Populate the 3-D Gap Matrix
+
+1. For each `brand × engine × intent` cell, compute citation count, average position, sentiment distribution.
+2. For unstable citations (cited in only 1 of 3 runs), apply the 0.33 confidence weight.
+
+### Step 7: Assign Per-Quadrant Verdicts and Generate Gap Narrative
+
+1. Apply the verdict rubric to each of the 24 `engine × intent` quadrants.
+2. For each CRITICAL_GAP and LAGGING quadrant, generate the 5-sentence narrative.
+
+### Step 8: Map Each Gap to Top-3 Remediation Items
+
+1. For each LAGGING quadrant, propose 1 remediation action.
+2. For each CRITICAL_GAP quadrant, propose up to 2 remediation actions.
+3. Roll up to a top-3 prioritized list (by gap-count weight × intent priority from the matrix).
+4. Each remediation item names the owner skill and the specific command to run next.
+
+---
+
+## Upstream and Downstream Skill Hooks
+
+### Upstream
+
+| Upstream skill | What this skill consumes |
+|---|---|
+| `geo-intent-matrix` | Probe questions (top-5 per quadrant) and intent taxonomy |
+| `geo-brand-mentions` | Competitor brand presence inventory; alias hints |
+| `geo-citation-pipeline` | Per-URL pipeline state (informs whether a content gap or an indexing gap) |
+
+### Downstream
+
+| Downstream skill | What this skill feeds it |
+|---|---|
+| `geo-content` | New piece briefs sourced from CRITICAL_GAP narratives |
+| `geo-distribution-plan` | Tier A surface targets identified in competitor citations |
+| `geo-citation-pipeline` | URL list to re-run pipeline on for LAGGING content with indexing gaps |
+| `geo-intent-matrix` | Re-balance the next-quarter matrix toward gap-heavy quadrants |
+
+---
+
+## Output Format
+
+Generate `~/.geo-prospects/competitor/<my-domain>-<YYYY-MM-DD>.md`:
+
+```markdown
+# GEO Competitor Citation Gap Report
+
+**My domain:** <my-domain>
+**Competitors:** <c1>, <c2>, <c3>, <c4>
+**Run date:** <YYYY-MM-DD>
+**Topic scope:** <from matrix `<topic>` / "matrix-less probe set">
+**Probes executed:** 20 questions × 6 engines × 3 runs = 360 probes
+**Engines captured programmatically:** Perplexity, Google AI Overviews
+**Engines captured manually:** ChatGPT, Claude, Gemini, Microsoft Copilot
+
+---
+
+## Executive Summary
+
+**Verdict roll-up (24 quadrants):**
+
+| Verdict | Count |
+|---|---|
+| LEADING | <n> |
+| PARITY | <n> |
+| LAGGING | <n> |
+| CRITICAL_GAP | <n> |
+
+**Headline:** <one paragraph summarizing the dominant pattern>
+
+---
+
+## Gap Matrix — Citation Count (my-domain only)
+
+| Intent \ Engine | ChatGPT | Claude | Perplexity | Gemini | Copilot | AI Overviews |
+|---|---|---|---|---|---|---|
+| Definitional | <n>/5 | <n>/5 | <n>/5 | <n>/5 | <n>/5 | <n>/5 |
+| Comparative | <n>/5 | <n>/5 | <n>/5 | <n>/5 | <n>/5 | <n>/5 |
+| Procedural | <n>/5 | <n>/5 | <n>/5 | <n>/5 | <n>/5 | <n>/5 |
+| Causal | <n>/5 | <n>/5 | <n>/5 | <n>/5 | <n>/5 | <n>/5 |
+
+## Gap Matrix — Per-Quadrant Verdict
+
+| Intent \ Engine | ChatGPT | Claude | Perplexity | Gemini | Copilot | AI Overviews |
+|---|---|---|---|---|---|---|
+| Definitional | LEADING | PARITY | … | | | |
+| Comparative | LAGGING | CRITICAL_GAP | … | | | |
+| Procedural | … | | | | | |
+| Causal | … | | | | | |
+
+## Competitor Comparison — Average Position per Quadrant
+
+(format repeats for each competitor; lower is better; "—" = NOT CITED)
+
+### Competitor: <c1>
+
+| Intent \ Engine | ChatGPT | Claude | Perplexity | Gemini | Copilot | AI Overviews |
+|---|---|---|---|---|---|---|
+| Definitional | 1.5 | — | 2.0 | 1.0 | — | 3.0 |
+| … | | | | | | |
+
+---
+
+## Gap Narratives (CRITICAL_GAP and LAGGING quadrants)
+
+### CRITICAL_GAP — Perplexity × Comparative
+
+1. On Perplexity for Comparative questions, you were cited 0 times across the 5 probes.
+2. The best-performing competitor in that quadrant was <c1> with 4 citations (average position 1.5).
+3. The dominant cited source for <c1> was reddit.com/r/<sub> — appearing in 3 of the 4 cited answers.
+4. The gap is concentrated on probes C1, C3, C4, where Perplexity cited <c1> via their Reddit AMA from 6 months ago.
+5. The closest existing asset on your side is <url>, scoring 58 on geo-citability and ranked #8 in traditional SERP — the remediation hook is geo-distribution-plan (Reddit syndication wave).
+
+### LAGGING — ChatGPT × Procedural
+
+…
+
+---
+
+## Top-3 Remediation Actions
+
+| # | Owner skill | Action | Affected quadrants | Effort | Next command |
+|---|---|---|---|---|---|
+| 1 | geo-distribution-plan | Run a Reddit-first distribution plan for the Comparative topic <topic> | Perplexity×Comparative (CRITICAL_GAP), ChatGPT×Comparative (LAGGING) | M | `/geo distribute <topic>` |
+| 2 | geo-content + geo-intent-matrix | Author Definitional asset on <topic>; bind form to standalone definition block | Gemini×Definitional (CRITICAL_GAP) | L | `/geo content <new-url>` |
+| 3 | geo-citation-pipeline | Re-run pipeline on <url> with focus on Stage 5 rapid indexing | Copilot×Procedural (LAGGING) | S | `/geo pipeline <url>` |
+
+---
+
+## Raw Capture Locations
+
+Raw per-probe captures are stored under `~/.geo-prospects/competitor/_runs/<my-domain>-<YYYY-MM-DD>/`. Re-analysis without re-probing: rerun this skill with `--reanalyze`.
+```
+
+---
+
+## Quality Gates
+
+- **Minimum captures:** A quadrant verdict is only computed if ≥ 4 of the 5 probes in that intent returned a capture across all 6 engines. Quadrants with insufficient captures are marked `INSUFFICIENT_DATA`.
+- **Capture freshness:** Captures older than 30 days must not be reused — engine behavior drifts. The `--reanalyze` flag refuses to run if captures are stale.
+- **Competitor sanity:** No competitor list may exceed 4 entries. Beyond 4, the comparison loses interpretability and the run cost balloons. The skill rejects > 4 competitors at Step 1.
+- **Probe-set integrity:** If the input matrix has fewer than 5 questions in any quadrant, the missing quadrant is filled from the angle expansion templates and flagged in the output as `matrix-augmented`.
+- **Cost gate:** Before Step 3, the skill prints the probe budget (default 360) and pauses for user confirmation. The user can opt to run a reduced 2-runs-per-probe (240 probe) or 1-run-per-probe (120 probe) sweep at the cost of denoising fidelity.
+- **Sentiment classification confidence:** When a context_excerpt is too short (< 60 chars) or too ambiguous for confident sentiment classification, default to MENTIONED rather than guessing.
+
+---
+
+## Important Notes
+
+- **Manual capture is the bottleneck.** Four of six engines have no stable public-URL query interface. Be honest with the user about the time cost up front; budget 60–90 min of human time for a 4-engine manual capture pass (3 runs × 20 probes × 4 engines = 240 manual captures).
+- **Engine drift is real.** Re-running the same 20 probes 30 days later will produce a different matrix even with no content changes — engines update their indexes and tune their retrieval models on weekly-to-monthly cadences. Always include the run date in conclusions; trends across ≥ 3 runs are more informative than any single snapshot.
+- **The matrix is the artifact; the narrative is the product.** Quadrant verdicts are mechanical; the gap narratives are what the user can act on. Spend the most care on Step 7 — a perfunctory narrative produces no remediation.
+- **Avoid probing branded queries.** "What is `<my-brand>`?" or "`<my-brand>` reviews" produce uninteresting results (engines obviously cite the brand for its own name). The probe set must be intent-shaped questions about the topic, not the brand.
+- **This skill closes the GEO loop.** `geo-intent-matrix` plans the angles → `geo-citation-pipeline` wires each piece for citation → `geo-distribution-plan` syndicates → `geo-competitor-citation` measures whether the engines actually picked you. The remediation outputs feed back into the matrix for next quarter.

--- a/skills/geo-distribution-plan/SKILL.md
+++ b/skills/geo-distribution-plan/SKILL.md
@@ -1,0 +1,436 @@
+---
+name: geo-distribution-plan
+description: >
+  Authority-tiered multi-platform content distribution plan. Sits between
+  content creation and technical publishing. Builds a Tier 1/2/3 platform
+  scoring matrix, tags each platform with AI-training-corpus coverage,
+  produces a 14-day cadence (D0 main site → D+1 Tier 1 syndication → D+3
+  Tier 2 rewrites → D+7 Tier 3 + social cuts), supplies per-platform rewrite
+  constraints (Zhihu, WeChat, Xiaohongshu, CSDN/Juejin, LinkedIn, Medium,
+  Substack, Reddit, Hacker News, X Threads, vertical media), and a 7/14/30
+  day authority-signal reclaim checklist. Use when user says "distribute",
+  "distribution plan", "syndication", "publishing cadence", "channel plan",
+  "/geo distribute".
+version: 1.0.0
+author: geo-seo-claude-plus
+tags: [geo, distribution, syndication, channels, cadence, authority]
+allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
+---
+
+# GEO Distribution Plan Skill
+
+## Core Insight
+
+`geo-platform-optimizer` answers "*given my page, how do I tune it for each AI engine?*" — it optimizes a single artifact for a single surface. This skill answers a different question: "*given my topic, where do I publish, in what order, with what rewrites, so that AI training corpora and retrieval indexes pick up the topic from multiple high-authority entry points?*"
+
+Two facts make multi-platform distribution non-negotiable for GEO:
+
+1. **AI engines do not retrieve from one source.** A 2025 Profound study found Perplexity averages 4–8 cited sources per answer; ChatGPT search averages 2–4; Gemini and Google AI Overviews routinely pull from 3+ surfaces. A topic that exists on only your domain has at most a 1-in-N chance of being the cited source on any given answer — and that chance drops to zero if a higher-authority surface (Reddit thread, Wikipedia paragraph, top YouTube transcript) covers the same topic better.
+2. **The cost of mis-sequenced distribution is canonical confusion.** Dropping the same article verbatim on Medium, LinkedIn, and Substack on day 1 with no canonical or staggering teaches every engine that the canonical answer-location is ambiguous. Engines hedge by citing none of them and falling back to the older incumbent on the topic.
+
+The distribution plan therefore has three jobs: **(a)** pick the right platforms for the topic at the right tier, **(b)** sequence the publish moves over 14 days so each surface reinforces the next without canonical conflict, **(c)** prescribe per-platform rewrites that match each platform's audience and AI-corpus footprint without breaking the topical-cluster signal.
+
+---
+
+## How to Use This Skill
+
+1. Take a **topic** and the **canonical URL** of the source article on the main site.
+2. (Optional) Take an audience descriptor (B2B / B2C / dev-tools / consumer / regulated) — used to bias platform tier scoring.
+3. (Optional) Take a region (`global / cn / na / eu`) — used to gate Chinese vs. English-first platforms.
+4. Run the 7-step workflow below.
+5. Emit `~/.geo-prospects/distribution/<domain>-<topic-slug>-<YYYY-MM-DD>.md` with the tier matrix, 14-day cadence, per-platform briefs, and 7/14/30-day reclaim checklist.
+
+This skill must be invoked **only after `geo-citation-pipeline` returns PIPELINE_READY** for the canonical URL. Distribution amplifies whatever AI engines see on the destination — distributing a BLOCKED page wastes the effort.
+
+---
+
+## Platform Tiering Matrix
+
+Each candidate platform is scored on three dimensions and tiered. The tier governs sequencing and rewrite intensity.
+
+### Scoring dimensions
+
+| Dimension | What it measures | Score range |
+|---|---|---|
+| **Authority weight (A)** | Domain-level authority signal AI engines treat as a trust prior — proxied by Wikipedia citation frequency, DR equivalents, and editorial gating | 1–5 |
+| **AI-corpus coverage (C)** | Known or strongly inferred presence of the platform in major AI training sets (Common Crawl, vendor disclosures) and live retrieval indexes | KNOWN / PARTIAL / UNKNOWN |
+| **Audience fit (F)** | Match between the platform's audience and the topic's audience descriptor | 1–5 |
+
+`Tier_score = A × F` (range 1–25). Then bump up one tier if `C = KNOWN`, leave alone if `PARTIAL`, drop one tier if `UNKNOWN`.
+
+| Tier | Score range | Role |
+|---|---|---|
+| **Tier 1 — Authority Hub** | ≥ 16 | Syndicate first; minimal rewrite; full attribution back to canonical |
+| **Tier 2 — Authority Amplifier** | 8–15 | Rewrite with distinct opening; cross-link to Tier 1 + canonical |
+| **Tier 3 — Reach / Social Cut** | < 8 | Excerpt, snippet, or media cut; teaser link only |
+
+### Pre-scored platform reference
+
+This is the default scoring matrix. Adjust per topic / audience / region.
+
+| Platform | A | Default F | C | Default tier | Region | Audience fit notes |
+|---|---|---|---|---|---|---|
+| Wikipedia | 5 | 4 | KNOWN | T1 | global | Only for genuinely encyclopedic content; not for promotional posts |
+| Reddit (relevant subreddit) | 4 | 4 | KNOWN | T1 | global | Strongest Perplexity / ChatGPT signal; requires community-native voice |
+| Hacker News | 4 | 3 | KNOWN | T2 | global | Dev / B2B / startups only; strict no-promotion norms |
+| Stack Overflow / Stack Exchange | 5 | 3 | KNOWN | T1 | global | Procedural / Causal dev content only; must answer a real question |
+| YouTube (with transcript) | 4 | 4 | KNOWN | T1 | global | Transcripts are heavily indexed by Gemini and ChatGPT search |
+| Medium | 3 | 3 | KNOWN | T2 | global | Use canonical tag back to source; topic-tag for distribution |
+| Substack | 3 | 3 | PARTIAL | T2 | global | Best for Causal long-form; newsletter signal helps retention metrics |
+| LinkedIn (long-form Article) | 4 | 4 | PARTIAL | T2 | global | B2B / professional only; must have a personal hook |
+| Quora | 3 | 3 | KNOWN | T2 | global | Definitional + Comparative content only; must answer a real question |
+| 36Kr | 4 | 4 | PARTIAL | T1 | cn | Premium B2B / tech / startup outlet |
+| Huxiu | 4 | 4 | PARTIAL | T1 | cn | B2B / business / industry analysis |
+| Zhihu | 5 | 4 | PARTIAL | T1 | cn | Strongest Chinese AI-search citation source; long-form Q&A |
+| WeChat Official Account | 4 | 4 | UNKNOWN | T2 | cn | Closed garden — AI-corpus coverage is unverified; valuable for owned-audience retention |
+| Xiaohongshu | 3 | 3 | UNKNOWN | T3 | cn | Consumer / lifestyle / visual; rarely cited by Western engines |
+| CSDN | 3 | 4 | PARTIAL | T2 | cn | Developer / technical content |
+| Juejin | 3 | 4 | PARTIAL | T2 | cn | Developer / front-end / engineering |
+| Industry trade outlets (e.g. TechCrunch, The Verge, Ars Technica, IEEE Spectrum) | 5 | varies | KNOWN | T1 | global | Editorial gate; pursue as pitched contribution, not self-publish |
+| G2 / Capterra / Trustpilot | 4 | 3 | KNOWN | T2 | global | Comparative content only; review-based platforms |
+| X (Twitter) Threads | 2 | 3 | UNKNOWN | T3 | global | Reach-only; X feed is intermittently in AI corpora |
+| Personal blog cross-post | 2 | varies | UNKNOWN | T3 | global | Useful only if the blog has an established audience |
+
+---
+
+## AI-Training-Corpus Coverage Tags
+
+The C dimension carries strategic weight. Tag each platform with one of:
+
+| Tag | Meaning | Source of evidence |
+|---|---|---|
+| **KNOWN** | Documented in published Common Crawl analyses, major model technical reports, or vendor disclosures | Public research, e.g., Reddit and Wikipedia in Common Crawl; YouTube transcripts in Google's training disclosures |
+| **PARTIAL** | Substantial evidence the platform appears in retrieval indexes (live search) even if training inclusion is uncertain | Observed in Perplexity / ChatGPT search citations |
+| **UNKNOWN** | No reliable evidence of inclusion in either training or retrieval | Closed gardens (WeChat); platforms with aggressive robots blocking |
+
+**Strategic rule:** UNKNOWN platforms are not worthless — they are valuable for **owned-audience retention** and **conversion** — but they should never anchor a GEO distribution plan. Always pair an UNKNOWN platform with at least one KNOWN platform in the same week to preserve AI-corpus reach.
+
+---
+
+## 14-Day Cadence Template
+
+Default sequence assumes 1 canonical URL + 2–4 Tier 1 platforms + 3–6 Tier 2 platforms + Tier 3 fills the rest.
+
+| Day | Move | Platforms | Rewrite intensity | Canonical handling |
+|---|---|---|---|---|
+| **D0** | Publish canonical | Main domain | None | Self-canonical; ping IndexNow |
+| **D+1** | Tier 1 syndication wave | 1–2 Tier 1 platforms (e.g., Reddit relevant subreddit + Zhihu for CN) | Distinct opening (first 100 words) + native formatting; body may be near-verbatim | `rel="canonical"` to main URL where supported; explicit attribution otherwise |
+| **D+2** | Quiet day | — | — | Allow indexing to settle |
+| **D+3** | Tier 2 rewrite wave A | 2–3 Tier 2 platforms (e.g., Medium + LinkedIn + 36Kr) | Distinct opening + distinct conclusion; reorganize body into platform-native structure; insert at least one platform-specific example | Canonical tag where available; cross-link to D+1 syndication where relevant |
+| **D+5** | Tier 2 rewrite wave B | 1–2 more Tier 2 (e.g., Substack newsletter, Quora answer) | Same as D+3 | Same |
+| **D+7** | Tier 3 + social cuts | X thread, LinkedIn post (short-form), Xiaohongshu cut if CN | Pure excerpt or snippet | Teaser link to canonical |
+| **D+10** | Authority follow-up | If applicable: pitch to industry editorial outlet, Wikipedia citation if eligible | Editorial workflow | External canonical, ledes the source |
+| **D+14** | Reclaim checkpoint #1 | All published surfaces | — | Run the 7/14/30 reclaim checklist |
+
+### Conflict-avoidance rules
+
+- **Never publish two near-verbatim copies on the same day on KNOWN-corpus platforms.** Stagger by at least 24 h.
+- **Use `rel="canonical"` to the main URL** on Medium, LinkedIn Articles, Substack (custom-domain accounts), Quora answers — wherever the platform supports it.
+- **For platforms that do not support canonical** (Reddit, Zhihu, WeChat, X), require a distinct opening (≥ 100 words) and an explicit attribution line linking to the canonical source.
+- **Reddit and Hacker News are not "distribution channels" — they are communities.** Treat them as topic-native posts authored by a human contributor, not as syndication. Auto-cross-posting will be reported as spam.
+- **WeChat Official Account content is canonical-only inside WeChat.** Do not also publish the same article on Zhihu the same week — split the topic into a Zhihu Q&A angle and a WeChat editorial angle.
+
+---
+
+## Per-Platform Rewrite Constraints
+
+Each platform has structural and tonal conventions that, if violated, degrade engagement and may suppress AI-corpus inclusion (because low-engagement posts get pushed out of retrieval indexes).
+
+### Zhihu
+
+- **Opening pattern:** Pose a sharp question; do not start with a definition. Question-hook → personal stake → answer.
+- **Length:** 1500–4000 Chinese characters for Tier 1 treatment.
+- **Format:** First-person voice, conversational, with bolded inline takeaways. Use Zhihu's native image and code blocks; avoid embedded screenshots from the canonical post.
+- **CTA:** No external link in the first 30 % of the post. Source attribution at the end as a "推荐阅读" (Recommended reading) link.
+
+### WeChat Official Accounts
+
+- **Opening pattern:** Cover image card + 1-sentence editorial hook + 3-bullet TL;DR ("本文重点").
+- **Length:** 800–2500 Chinese characters; readers skim on mobile.
+- **Format:** Short paragraphs (2–3 sentences); use 小标题 (sub-headings) every 200–300 characters; insert 1–2 illustrations.
+- **CTA:** Soft CTA at the end (关注 / 收藏); external links only via reply-keyword pattern, not inline.
+
+### Xiaohongshu
+
+- **Opening pattern:** Visual-first; the cover image carries the hook text.
+- **Length:** 300–800 characters; high emoji density tolerated.
+- **Format:** Numbered listicle or before/after structure; topic tags (#) at the end.
+- **CTA:** Profile-link follow rather than external link; external links are heavily deprioritized.
+
+### CSDN / Juejin
+
+- **Opening pattern:** Problem statement → environment / version → solution overview.
+- **Length:** 1500–5000 characters; code blocks expected.
+- **Format:** Working code, version-pinned dependencies, reproducible commands. Diagrams welcome.
+- **CTA:** Source repo link at the bottom; canonical link in author bio.
+
+### LinkedIn (long-form Article)
+
+- **Opening pattern:** First-person professional anecdote → reframe to topic → industry insight.
+- **Length:** 800–1800 words; readers skim from feed.
+- **Format:** Bold subheadings every 150–200 words; one chart or quote-pull per 500 words.
+- **CTA:** Comments-prompt question at the end; canonical link at the bottom with "Originally published at …".
+
+### Medium
+
+- **Opening pattern:** TL;DR or one-line subtitle (Medium's subtitle field is critical for distribution).
+- **Length:** 1200–2500 words for the algorithm's "long-read" boost.
+- **Format:** Pull quotes for tweetable lines; one image every 400–600 words; topic tags (max 5) at publish time.
+- **CTA:** Canonical link to source via Medium's "Import a story" or `rel="canonical"`; follow CTA at the bottom.
+
+### Substack
+
+- **Opening pattern:** Editorial cold-open; tease the payoff in the subject line.
+- **Length:** 1500–3500 words for Causal long-form; 800–1500 for digest format.
+- **Format:** Bold subheads; pullout boxes; image at the top.
+- **CTA:** Subscribe button mid-piece; canonical link at the bottom; cross-post toggle on if the source domain is also a Substack publication.
+
+### Reddit
+
+- **Opening pattern:** Genuine question or experience post; no marketing language.
+- **Length:** 200–800 words for the post body; expect to defend in comments.
+- **Format:** Plain text or light markdown; respect the subreddit's specific rules (no link drops, no surveys, etc.).
+- **CTA:** None overt. Link only if asked in comments. Author flair / username should not be obviously promotional.
+
+### Hacker News
+
+- **Opening pattern:** "Show HN" / "Ask HN" prefix where appropriate; otherwise straight title.
+- **Length:** Link post or text post under 500 words.
+- **Format:** No marketing language; technical specifics in the title. Stay in the comment thread to answer questions.
+- **CTA:** None. Post the link; the link is the CTA.
+
+### X (Twitter) Threads
+
+- **Opening pattern:** Hook tweet with a counter-intuitive claim or a number.
+- **Length:** 5–12 tweets; each ≤ 280 chars; visuals on tweet 1 and tweet 5+.
+- **Format:** Numbered ("1/", "2/") or implied threading; quotable single-line takeaways.
+- **CTA:** Final tweet: link + ask for engagement.
+
+### Vertical Media (36Kr, Huxiu, TechCrunch, The Verge, etc.)
+
+- **Opening pattern:** Editorial — pitched via the outlet's contribution flow.
+- **Length:** Defined by outlet (typically 800–2000 words).
+- **Format:** Outlet's house style, editorial review.
+- **CTA:** No CTA — the byline and bio link carry the attribution.
+
+---
+
+## Authority-Signal Reclaim Checklist (7 / 14 / 30 days)
+
+Distribution is incomplete without recapturing the authority signals downstream platforms generate.
+
+### Day 7 checkpoint
+
+- [ ] Count inbound backlinks created in the past 7 days (use Ahrefs/Moz/manual scan or fetch from the linking platforms directly).
+- [ ] Catalog new brand mentions on Tier 1 and Tier 2 platforms (linked + unlinked).
+- [ ] Verify each Tier 1 syndication has the correct canonical or attribution.
+- [ ] Confirm IndexNow ping for each platform-syndicated URL where applicable.
+- [ ] Flag any platform where the cross-post is ranking above the canonical for the primary query.
+
+### Day 14 checkpoint
+
+- [ ] Run Stage 6 of `geo-citation-pipeline` (preferred-answer verification) — has any AI engine started citing the topic? Which surface gets cited?
+- [ ] Identify which platforms' versions are being cited (you may discover Reddit or Zhihu is the cited surface, not the canonical — that's a signal, not a failure).
+- [ ] Confirm no canonical-confusion penalty on the canonical URL (sudden organic-traffic drop or rank loss is the warning sign).
+- [ ] Track engagement signals on each platform (upvotes, comments, saves) and rank the platforms by `(engagement × A-tier)` to inform the next plan.
+
+### Day 30 checkpoint
+
+- [ ] Run `/geo compete <domain> <competitors>` — has the competitor matrix changed for this topic?
+- [ ] Catalog any earned coverage (industry outlets picked up the topic, podcasts referenced the canonical, etc.).
+- [ ] Decide on a second-wave amplification: republish on platforms that missed the first wave, or escalate to a press push.
+- [ ] Archive the result into `~/.geo-prospects/distribution/_archive/` for cross-plan trend analysis.
+
+---
+
+## Workflow
+
+### Step 1: Resolve Source Article and Target Topic
+
+1. Capture the canonical URL and the topic phrase.
+2. Look up the topic in the latest `~/.geo-prospects/matrices/<domain>-*.md` if present — pull the planned `intent:` and `question:` for downstream use.
+3. Confirm `geo-citation-pipeline` returned PIPELINE_READY for the URL — if not, abort with a clear error message and instruct the user to remediate first.
+
+### Step 2: Filter Platforms by Audience Fit and Tier Eligibility
+
+1. Apply the audience descriptor and region inputs to the pre-scored platform reference table.
+2. Drop platforms with `F < 3` for the topic's audience.
+3. Drop platforms that conflict with the topic content type (e.g., Stack Overflow for a marketing post; Xiaohongshu for an enterprise security topic).
+4. Compute `Tier_score = A × F` and apply the C-tag bump/drop.
+5. Confirm the final shortlist has at least 2 Tier 1 + 3 Tier 2 + 2 Tier 3 platforms. If not, document the gap.
+
+### Step 3: Tag Each Selected Platform with AI-Corpus Coverage
+
+1. Re-confirm each platform's C tag using the latest evidence (some platforms move from PARTIAL to KNOWN as new disclosures appear).
+2. For any UNKNOWN platform retained in the plan, document the strategic reason (owned-audience retention, regional dominance, conversion).
+
+### Step 4: Emit 14-Day Cadence Calendar
+
+1. Slot each selected platform into the appropriate cadence day based on its tier.
+2. Resolve scheduling conflicts using the conflict-avoidance rules.
+3. Add `geo-citation-pipeline` re-run on day 14 to Stage 6 verify.
+
+### Step 5: Generate Per-Platform Rewrite Briefs
+
+1. For each platform in the plan, produce a brief that includes: opening pattern, length target, format constraints, CTA pattern, and canonical/attribution treatment.
+2. For each Tier 2 rewrite, also produce a distinct first-100-word opening proposal (the engineering test of "distinct" is at least 60 % token-distinct from the canonical's first 100 words).
+3. Save briefs as inline sections in the output file — do not generate the actual post bodies.
+
+### Step 6: Wire Conflict-Avoidance Directives
+
+1. For each platform that supports canonical, generate the exact `<link rel="canonical">` HTML or platform setting required.
+2. For each platform that does not, generate the attribution sentence to paste.
+3. Verify no two KNOWN-corpus platforms are scheduled within 24 h of each other.
+
+### Step 7: Schedule 7/14/30-Day Reclaim Audits
+
+1. Generate the three checkpoint TODO blocks (Day 7, Day 14, Day 30) as inline sections in the output.
+2. Cross-link the Day 14 block to a `geo-citation-pipeline --verify` re-run command.
+3. Cross-link the Day 30 block to a `/geo compete` invocation.
+
+---
+
+## Upstream and Downstream Skill Hooks
+
+### Upstream
+
+| Upstream skill | What this skill consumes |
+|---|---|
+| `geo-intent-matrix` | Topic, intent, question text for tier biasing |
+| `geo-citation-pipeline` | PIPELINE_READY gate — required to proceed |
+| `geo-brand-mentions` | Existing platform presence on Tier 1/2 (avoid recommending platforms where the brand already has poor reputation) |
+| `geo-platform-optimizer` | Per-AI-engine preferences — used to bias Tier 1 selection (e.g., if the topic is Procedural and dev-focused, Stack Overflow + Hacker News rise in tier score) |
+
+### Downstream
+
+| Downstream skill | What this skill feeds it |
+|---|---|
+| `geo-citation-pipeline` (Day 14 re-run) | Trigger for Stage 6 verification across all syndicated surfaces |
+| `geo-competitor-citation` (Day 30) | Trigger for full gap analysis on the topic |
+| `geo-compare` | Distribution wave produces new entity mentions and inbound links — these become inputs to the next monthly delta |
+
+---
+
+## Output Format
+
+Generate `~/.geo-prospects/distribution/<domain>-<topic-slug>-<YYYY-MM-DD>.md`:
+
+```markdown
+# GEO Distribution Plan: <Topic>
+
+**Canonical URL:** <url>
+**Topic:** <topic>
+**Intent (from matrix):** <Definitional / Comparative / Procedural / Causal>
+**Audience:** <descriptor>
+**Region:** <global / cn / na / eu>
+**Pipeline gate:** PIPELINE_READY (verified <YYYY-MM-DD>)
+**Plan generated:** <YYYY-MM-DD>
+
+---
+
+## Tier Matrix
+
+| Platform | A | F | C | Tier_score | Final tier | Notes |
+|---|---|---|---|---|---|---|
+| <platform> | 5 | 4 | KNOWN | 20 | T1 | <one-line> |
+| … | | | | | | |
+
+**Shortlist gap:** [None / list of missing tier slots]
+
+---
+
+## 14-Day Cadence
+
+| Day | Platform | Tier | Rewrite intensity | Canonical handling |
+|---|---|---|---|---|
+| D0 | Main domain | — | None | Self-canonical |
+| D+1 | <platform> | T1 | Distinct opening | <rel=canonical / attribution> |
+| D+1 | <platform> | T1 | Distinct opening | <…> |
+| D+3 | <platform> | T2 | Distinct opening + conclusion | <…> |
+| … | | | | |
+
+---
+
+## Per-Platform Rewrite Briefs
+
+### <Platform 1>
+
+- **Opening pattern:** <…>
+- **Length:** <…>
+- **Format:** <…>
+- **CTA:** <…>
+- **Canonical/attribution:** <exact HTML or sentence>
+- **Distinct first-100-word opening proposal:**
+
+> <proposed opening>
+
+### <Platform 2>
+
+…
+
+---
+
+## Day 7 Reclaim Checkpoint
+
+- [ ] Count inbound backlinks created in past 7 days
+- [ ] Catalog new brand mentions on Tier 1 and Tier 2
+- [ ] Verify canonical / attribution on each Tier 1 syndication
+- [ ] Confirm IndexNow ping for syndicated URLs
+- [ ] Flag any cross-post outranking the canonical
+
+## Day 14 Reclaim Checkpoint
+
+- [ ] Run `/geo pipeline <url> --verify` for Stage 6 preferred-answer verification
+- [ ] Identify which surface AI engines cite
+- [ ] Confirm no canonical-confusion penalty on the canonical URL
+- [ ] Rank platforms by (engagement × A-tier)
+
+## Day 30 Reclaim Checkpoint
+
+- [ ] Run `/geo compete <domain> <competitors>` — has the gap matrix changed?
+- [ ] Catalog earned coverage (industry outlets, podcasts, conferences)
+- [ ] Decide on second-wave amplification
+- [ ] Archive plan to `~/.geo-prospects/distribution/_archive/`
+
+---
+
+## Conflict-Avoidance Audit
+
+- [ ] No two KNOWN-corpus platforms scheduled within 24 h of each other
+- [ ] Every cross-post on a canonical-supporting platform has `rel="canonical"` to the main URL
+- [ ] Every cross-post on a non-canonical platform has explicit attribution
+- [ ] Reddit / Hacker News posts are authored in community-native voice (no marketing language)
+- [ ] WeChat and Zhihu treatments cover different topic angles, not duplicated content
+
+---
+
+## Plan State
+
+[PLAN_READY / PLAN_INCOMPLETE / BLOCKED]
+
+- **PLAN_READY** — shortlist meets minimum tier coverage, all conflict rules pass
+- **PLAN_INCOMPLETE** — missing Tier 1 or Tier 2 coverage; suggested actions listed
+- **BLOCKED** — pipeline gate failed; remediate upstream first
+```
+
+---
+
+## Quality Gates
+
+- **Pipeline gate:** Never emit a plan when `geo-citation-pipeline` is BLOCKED for the canonical URL.
+- **Minimum platform coverage:** Plans must include ≥ 2 Tier 1, ≥ 3 Tier 2 platforms. If coverage cannot be met given the audience/region inputs, downgrade to PLAN_INCOMPLETE and list the missing slots.
+- **AI-corpus ratio:** At least 50 % of selected platforms must be tagged KNOWN. UNKNOWN-heavy plans drive owned-audience retention but not AI citation, and the output file must call that out explicitly.
+- **Cadence rate limit:** Maximum 2 publish moves per day. The 14-day window provides enough slots that hitting this cap is never necessary.
+- **Canonical conflict:** Any two near-verbatim posts on KNOWN-corpus platforms scheduled within 24 h is a hard fail — re-stagger before emitting.
+- **Brief specificity:** Every per-platform brief must include the four required elements (opening pattern, length, format, CTA). Missing any element is a plan defect.
+
+---
+
+## Important Notes
+
+- This plan is **strategy, not execution.** It tells you what to publish where and in what order; it does not write the platform-specific posts. Use `geo-content` (or your in-house team) to produce the actual copy from each brief.
+- The per-platform rewrite briefs are **constraints, not templates.** Two writers given the same brief should produce visibly different posts that both satisfy the constraints.
+- **UNKNOWN platforms are not bad — they are owned.** WeChat Official Accounts and Substack newsletters drive subscriber retention and direct conversion, which over time create the engagement signals that move PARTIAL platforms toward KNOWN status. Keep at least one UNKNOWN platform per plan for owned-audience compounding.
+- **Reddit posting is high-risk.** Each subreddit has its own rules; one wrong post can earn a permanent ban and damage the brand on the strongest AI-citation surface. When in doubt, prefer Quora or LinkedIn over Reddit for the same content angle.
+- **Wikipedia is mentioned for completeness but rarely actionable in a 14-day window.** Wikipedia eligibility requires established sourcing across multiple independent secondary outlets; treat it as the **outcome of months of distribution**, not a destination in any single plan.
+- **Region gating matters.** A `region: cn` plan should not waste tier slots on Western platforms (Medium, Substack) unless the brand has an explicit English-language strategy. A `region: global` plan must include both Eastern and Western Tier 1 entries.

--- a/skills/geo-intent-matrix/SKILL.md
+++ b/skills/geo-intent-matrix/SKILL.md
@@ -1,0 +1,425 @@
+---
+name: geo-intent-matrix
+description: >
+  Query-intent angle matrix for systematic GEO content coverage. Given a core
+  topic, generates a 4-quadrant intent matrix (Definitional / Comparative /
+  Procedural / Causal), scores each candidate question by search volume × AI
+  citation propensity × difficulty, binds each intent to a required content
+  form, and emits a 12-week rolling editorial schedule with downstream hooks
+  into geo-citation-pipeline, geo-distribution-plan, and geo-competitor-citation.
+  Use when user says "matrix", "intent matrix", "content angles", "intent angles",
+  "topic plan", "/geo matrix", or asks how to systematically cover a topic for
+  AI search.
+version: 1.0.0
+author: geo-seo-claude-plus
+tags: [geo, intent, content-strategy, planning, matrix, coverage]
+allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
+---
+
+# GEO Intent-Angle Matrix Skill
+
+## Core Insight
+
+AI search engines do not cite "the best article" — they cite the article that best matches the **shape of the user's question**. Every query the user types into ChatGPT, Perplexity, Claude, Gemini, Copilot, or Google AI Overviews falls into one of four intent shapes: *what is this*, *which of these*, *how do I do this*, or *why does this happen*. Each shape rewards a structurally different content form. A site that publishes only "What is X" definitional content will be invisible whenever the user asks "X vs Y," "How to X," or "Why X" — no matter how high-quality the existing pages are.
+
+A 2025 Profound study analyzing 40,000 AI search citations across the five major engines found that **Definitional** content drives 31 % of citations, **Comparative** 27 %, **Procedural** 24 %, and **Causal** 18 %. A site covering only one quadrant therefore caps its addressable AI-citation surface at roughly a quarter of the maximum. Coverage breadth across all four intents matters more than depth in any single one.
+
+This skill turns one core topic into a 12-week rolling editorial plan that systematically populates all four quadrants, scores each candidate question by ROI, binds each intent to its required content form (so downstream `geo-content` can produce the right structure), and wires each planned piece into the rest of the GEO loop.
+
+---
+
+## How to Use This Skill
+
+1. Collect a single **core topic** (1–4 words, the central entity the site wants to be cited for).
+2. Collect the **target domain** so the coverage heat-map can be built from the live sitemap and prior `geo-brand-mentions` data.
+3. (Optional) Collect a list of 3–10 **seed entities** the topic should co-occur with (related products, methods, audiences).
+4. Run the 6-step workflow below.
+5. Emit `~/.geo-prospects/matrices/<domain>-<topic>-<YYYY-MM-DD>.md`.
+
+---
+
+## The Four Intent Angles (Taxonomy)
+
+Every candidate question must be classified into exactly one of these four buckets. If a question fits two, split it into two questions.
+
+### Definitional (What is X)
+
+**Trigger when:** the user is encountering a concept, product, technology, or term for the first time and needs a clean mental model.
+
+**Surface patterns:**
+- "What is `<term>`?"
+- "`<term>` meaning / definition / explained"
+- "What does `<term>` mean in `<context>`?"
+- "`<term>` overview / introduction"
+- "What is `<term>` used for?"
+
+**Why AI engines cite it:** Definitional passages are the highest-value training-and-retrieval blocks because they let an LLM produce a confident opening sentence. Engines preferentially extract a single 134-167 word self-contained paragraph that opens with "X is …" or "X refers to …".
+
+**Required content form:** see [Intent → Content-Form Binding](#intent--content-form-binding).
+
+### Comparative (X vs Y)
+
+**Trigger when:** the user is in active selection mode and needs to choose between options.
+
+**Surface patterns:**
+- "`<X>` vs `<Y>`"
+- "Best `<category>` (2026)"
+- "Top N `<category>` for `<use-case>`"
+- "Which is better, `<X>` or `<Y>`?"
+- "`<X>` alternatives"
+- "`<X>` vs `<Y>` vs `<Z>` comparison"
+
+**Why AI engines cite it:** Comparative queries trigger high-confidence table extraction. Engines prefer pages that present 3+ options in a side-by-side table with consistent columns (price, feature, audience) — they can then re-render the table directly in the answer.
+
+### Procedural (How to X)
+
+**Trigger when:** the user has decided and is now executing a task.
+
+**Surface patterns:**
+- "How to `<verb>` `<object>`"
+- "Steps to `<verb>` `<object>`"
+- "`<verb>` `<object>` tutorial"
+- "Guide to `<verb>` `<object>`"
+- "How do I `<verb>` `<object>` in `<context>`?"
+
+**Why AI engines cite it:** Procedural queries trigger ordered-list extraction. Engines reward pages with explicit numbered steps, each step self-contained, with imperative verbs in step 1 of each item.
+
+### Causal (Why X)
+
+**Trigger when:** the user has hit a surprise and is asking for mechanism, root cause, or principle.
+
+**Surface patterns:**
+- "Why does `<phenomenon>` happen?"
+- "Why is `<X>` `<adjective>`?"
+- "How does `<X>` work?"
+- "What causes `<X>`?"
+- "Reason for `<X>`"
+
+**Why AI engines cite it:** Causal queries are the deepest funnel stage and the lowest-volume but highest-trust quadrant. Engines reward cause-and-effect chains supported by data, named studies, or first-party experiments. Causal content is the strongest E-E-A-T signal because it requires demonstrated expertise rather than aggregation.
+
+### Disambiguation rules
+
+If a candidate question fits two quadrants, apply these tie-breakers in order:
+
+1. If a number ("top 5", "best 3") is present → **Comparative**.
+2. If an imperative verb ("install", "set up", "configure", "run") is the head → **Procedural**.
+3. If "why" is the head wh-word → **Causal**.
+4. If "what" is the head wh-word and no list/verb is present → **Definitional**.
+5. If still ambiguous, split the question into two single-intent versions.
+
+---
+
+## Intent → Content-Form Binding
+
+This table is the contract consumed by `geo-content`. When `geo-content` is invoked on a page that the matrix planned, it must validate the page against the form for its intent.
+
+| Intent | Required Form | Minimum Structural Elements | Length Target | Reject If |
+|---|---|---|---|---|
+| Definitional | Standalone definition block 134–167 words at the top, then expansion | Opening "`<X>` is …" sentence; one named source within first 3 sentences; one numeric fact within first 6 sentences | 800–1500 words total | Opening sentence is narrative or hedged; no numeric fact in opening block |
+| Comparative | HTML table with ≥ 3 rows and ≥ 4 consistent columns | Header row; one row per option; columns include price-or-equivalent, primary feature, audience, verdict | 1200–2500 words total | Table absent; table has < 3 rows; columns inconsistent across rows |
+| Procedural | Ordered list with 5–15 numbered steps | Each step opens with imperative verb; each step is self-contained (no "as above"); a one-screenshot-or-code-block ratio per step is recommended | 1000–2000 words total | Steps are unnumbered prose; step 1 does not begin with imperative verb |
+| Causal | Cause → effect chain with named mechanisms and ≥ 2 cited studies | Explicit "because" connectors; named study/dataset citations; at least one data table OR diagram description | 1500–3000 words total | No named source; no mechanism named; ends in opinion without data |
+
+Each planned piece must declare its intent in the front-matter `intent:` field so downstream skills can validate the form binding.
+
+---
+
+## Angle Expansion Templates
+
+Given a core topic, mechanically expand candidate questions per quadrant. Aim for ≥ 5 candidates per intent (matrix minimum is 20 questions total).
+
+### Definitional expansion
+
+For core topic `T`:
+
+1. What is `T`?
+2. What is `T` used for?
+3. `T` vs related-but-distinct concept `R` (definitional, not comparative — clarifying boundary, not picking a winner)
+4. What is `T` in `<industry>` / for `<persona>`?
+5. History of `T` / where did `T` come from?
+6. `T` explained for `<expertise-level>` (beginners / engineers / executives)
+
+### Comparative expansion
+
+For core topic `T`:
+
+1. Best `T` solutions in `<year>`
+2. `T` vs `<top-alternative-1>`
+3. `T` vs `<top-alternative-2>`
+4. Top N `T` for `<use-case>`
+5. `T` alternatives
+6. `<vendor-A>` vs `<vendor-B>` in the `T` category
+
+### Procedural expansion
+
+For core topic `T`:
+
+1. How to start with `T`
+2. How to set up / configure / install `T`
+3. How to migrate from `<predecessor>` to `T`
+4. How to integrate `T` with `<adjacent-system>`
+5. How to debug / troubleshoot `T`
+6. How to scale / harden `T` for `<context>`
+
+### Causal expansion
+
+For core topic `T`:
+
+1. Why does `T` matter?
+2. Why is `T` `<surprising-property>`?
+3. How does `T` actually work under the hood?
+4. What causes `T` to fail / break / underperform?
+5. Why did `<industry>` move from `<predecessor>` to `T`?
+6. Why is `T` better / worse than `<alternative>` for `<criterion>` (mechanism, not verdict)
+
+---
+
+## Priority Scoring (Search Volume × AI Citation Propensity × Difficulty)
+
+Each candidate question gets a P-score on three factors, then the product is bucketed into P0/P1/P2.
+
+### Factor 1: Search Volume (SV)
+
+Estimate monthly search volume for the question. Use Bash + WebFetch to pull from Google Suggest, People Also Ask, or any available keyword tool the user has wired up. If no tool is available, infer from query head/torso/tail length:
+
+| SV Bucket | Volume Range | Score |
+|---|---|---|
+| Head | 10k+/mo | 5 |
+| Upper torso | 1k–10k/mo | 4 |
+| Torso | 100–1k/mo | 3 |
+| Tail | 10–100/mo | 2 |
+| Long tail | < 10/mo | 1 |
+
+### Factor 2: AI Citation Propensity (AICP)
+
+How likely is this question to be answered by an AI engine rather than a traditional SERP. Use the 2025 Profound distribution as the prior:
+
+| Intent | Base AICP | Adjustments |
+|---|---|---|
+| Definitional | 4 | +1 if topic is < 5 years old (engines preferred for fresh terms) |
+| Comparative | 5 | +0, –1 if traditional review sites dominate the SERP |
+| Procedural | 4 | +1 if topic is technical / developer-oriented; –1 if topic is regulated (legal/medical) |
+| Causal | 3 | +1 if topic requires synthesizing multiple sources |
+
+Floor at 1, cap at 5.
+
+### Factor 3: Difficulty (D)
+
+Inverted — higher difficulty subtracts from P-score. Estimate from existing competitor coverage observed during `geo-competitor-citation` runs, or fall back to a default of 3.
+
+| D Bucket | Description | Score (inverted) |
+|---|---|---|
+| Open | No strong incumbent answer | 5 |
+| Contested | Several incumbents but no consensus citation | 4 |
+| Crowded | Multiple high-authority answers | 3 |
+| Locked | Wikipedia + 2+ top-DR sites dominate every engine | 2 |
+| Saturated | Brand has zero realistic shot of displacing incumbents | 1 |
+
+### P-score and Bucketing
+
+`P = SV × AICP × D` (range 1–125)
+
+| Bucket | Range | Meaning |
+|---|---|---|
+| **P0** | ≥ 60 | Must-publish this quarter |
+| **P1** | 30–59 | Publish next quarter |
+| **P2** | < 30 | Backlog; revisit annually |
+
+---
+
+## Coverage Heat-Map Self-Check
+
+Before emitting the 12-week schedule, render the current state of the site against the 4 quadrants.
+
+### Inputs
+
+1. **Sitemap scan** — fetch `/sitemap.xml`, list every URL whose title or H1 contains the core topic or a seed entity.
+2. **Existing entity coverage** — read the latest `~/.geo-prospects/audits/<domain>-*.md` if present and extract any brand-mention entities already inventoried.
+3. **For each candidate question** in the expanded matrix, mark it as `COVERED`, `PARTIAL`, or `MISSING` based on URL-title fuzzy match against the sitemap.
+
+### Heat-Map Output (always render)
+
+```
+                COVERAGE BY INTENT QUADRANT
+
+                Definitional   Comparative   Procedural    Causal
+P0 (must-do)    [█ COVERED]    [░ MISSING]   [▒ PARTIAL]   [░ MISSING]
+P1 (next Q)     [▒ PARTIAL]    [░ MISSING]   [░ MISSING]   [░ MISSING]
+P2 (backlog)    [▒ PARTIAL]    [░ MISSING]   [░ MISSING]   [░ MISSING]
+
+Coverage score: 18 % (3 of 16 cells covered or partial)
+Critical gaps: P0 Comparative, P0 Causal
+```
+
+Coverage score = (`COVERED` cells × 1.0 + `PARTIAL` cells × 0.5) / total cells.
+
+---
+
+## Workflow
+
+### Step 1: Resolve Core Topic and Seed Entities
+
+1. Capture the core topic from the user invocation.
+2. If the user did not provide seed entities, infer 3–10 from the homepage of the target domain via WebFetch (look for navigation items, product names, repeated noun phrases).
+3. Confirm topic and seeds before proceeding.
+
+### Step 2: Expand Candidate Questions per Quadrant
+
+1. Apply the four expansion templates above to the core topic.
+2. Generate **at least 5** candidates per quadrant. Aim for 6 to leave room for filtering. Final matrix size: 20–24 questions.
+3. For each candidate, classify via the disambiguation rules. If a question lands in the wrong quadrant after generation, move or split it.
+
+### Step 3: Score and Triage (P0 / P1 / P2)
+
+1. Compute SV, AICP, D for every candidate.
+2. Multiply for P-score; bucket into P0/P1/P2.
+3. Discard any candidate scoring < 8 (`SV=1 × AICP=2 × D=4` or worse) — these are not worth the production cost.
+
+### Step 4: Bind Each Item to a Content Form
+
+1. Look up the required form in the [Intent → Content-Form Binding](#intent--content-form-binding) table.
+2. Add the form spec to each item's plan record. This becomes the contract for `geo-content` later.
+3. Flag any item where the user has indicated a preference for a non-default form (e.g., they want a Causal piece presented as a video) — note the deviation but warn that citation propensity may drop.
+
+### Step 5: Build Coverage Heat-Map from Sitemap + Brand-Mentions Inventory
+
+1. Fetch the site's sitemap.
+2. For each candidate, fuzzy-match against existing URLs (title + slug match at ≥ 60 % similarity).
+3. Mark COVERED / PARTIAL / MISSING.
+4. Render the heat-map block in the output.
+
+### Step 6: Emit 12-Week Rolling Schedule with Downstream Hooks
+
+1. Order all P0 items first, then P1, then P2.
+2. Spread items across 12 weeks (typically 1–2 items/week).
+3. For each scheduled item, emit a row with the following columns:
+
+```
+Week | Intent | Question | Form | P-score | Downstream actions
+```
+
+Where Downstream actions is a comma-separated list selected from:
+
+- `→ geo-citation-pipeline` (run after publication)
+- `→ geo-distribution-plan` (run on publication day)
+- `→ geo-competitor-citation` (run 14 days post-publication to confirm engine pickup)
+
+Every P0 item gets all three downstream hooks. P1 items get `geo-citation-pipeline` + `geo-distribution-plan`. P2 items get `geo-citation-pipeline` only.
+
+---
+
+## Downstream Skill Hooks
+
+This matrix is the upstream contract for three downstream skills. The hooks are:
+
+| Downstream Skill | What the matrix feeds it |
+|---|---|
+| `geo-content` | Per-piece `intent:` value and required form spec — used to validate the draft before publication |
+| `geo-citation-pipeline` | The URL of each published piece, with its intent — pipeline tunes its on-page checks per intent (Comparative pages get table-extraction checks; Procedural pages get step-list checks) |
+| `geo-distribution-plan` | The full matrix as input topic universe — distribution plan picks tier targets per intent (Comparative content syndicates well to Reddit; Procedural to dev platforms; Causal to long-form like Substack/Medium) |
+| `geo-competitor-citation` | The same 20-question matrix is reused as the competitor probe set (avoiding duplicated taxonomy work) |
+
+---
+
+## Output Format
+
+Generate `~/.geo-prospects/matrices/<domain>-<topic>-<YYYY-MM-DD>.md` with the following structure:
+
+```markdown
+# GEO Intent Matrix: <Core Topic>
+
+**Domain:** <domain>
+**Generated:** <YYYY-MM-DD>
+**Core topic:** <topic>
+**Seed entities:** <entity-1>, <entity-2>, …
+
+**Matrix status:** [MATRIX_COMPLETE / MATRIX_PARTIAL / BLOCKED]
+
+---
+
+## Coverage Heat-Map
+
+```
+<heat-map block from Step 5>
+```
+
+**Coverage score:** <X>%
+**Critical gaps:** <list of P0 MISSING quadrants>
+
+---
+
+## Quadrant 1 — Definitional
+
+| # | Question | SV | AICP | D | P-score | Bucket | Status | Form |
+|---|---|---|---|---|---|---|---|---|
+| 1 | <question> | 4 | 5 | 4 | 80 | P0 | MISSING | Standalone definition block |
+| … | | | | | | | | |
+
+## Quadrant 2 — Comparative
+
+| # | Question | SV | AICP | D | P-score | Bucket | Status | Form |
+|---|---|---|---|---|---|---|---|---|
+| … | | | | | | | | |
+
+## Quadrant 3 — Procedural
+
+| # | Question | SV | AICP | D | P-score | Bucket | Status | Form |
+|---|---|---|---|---|---|---|---|---|
+| … | | | | | | | | |
+
+## Quadrant 4 — Causal
+
+| # | Question | SV | AICP | D | P-score | Bucket | Status | Form |
+|---|---|---|---|---|---|---|---|---|
+| … | | | | | | | | |
+
+---
+
+## 12-Week Rolling Schedule
+
+| Week | Intent | Question | Form | P-score | Downstream actions |
+|---|---|---|---|---|---|
+| 1 | Definitional | What is <topic>? | Standalone definition block | 100 | → geo-citation-pipeline, → geo-distribution-plan, → geo-competitor-citation |
+| 1 | Comparative | <topic> vs <alt> | HTML comparison table | 80 | → geo-citation-pipeline, → geo-distribution-plan, → geo-competitor-citation |
+| 2 | Procedural | How to <verb> <topic> | Ordered list 5–15 steps | 72 | → geo-citation-pipeline, → geo-distribution-plan, → geo-competitor-citation |
+| … | | | | | |
+
+---
+
+## Downstream Wire-Up
+
+For each P0 item published this quarter:
+
+1. Run `/geo pipeline <url>` to confirm the 5-stage citation pipeline is healthy.
+2. Run `/geo distribute <topic>` to generate the 14-day cadence calendar.
+3. Run `/geo compete <domain> <competitor1,competitor2,...>` 14 days post-publication to confirm engine pickup.
+
+---
+
+## Quality Gates
+
+- Matrix is **MATRIX_COMPLETE** iff every quadrant has ≥ 5 candidates and ≥ 1 P0.
+- Matrix is **MATRIX_PARTIAL** iff one or more quadrants has zero P0 candidates — the schedule will still emit but the gap section will flag the missing quadrant.
+- Matrix is **BLOCKED** iff the sitemap cannot be fetched or the core topic could not be resolved against the site.
+```
+
+---
+
+## Quality Gates
+
+- **Quadrant minimum:** Every quadrant must have ≥ 5 candidate questions after Step 2.
+- **P0 minimum per quadrant:** A quadrant with zero P0 items downgrades the matrix to MATRIX_PARTIAL and is flagged in the heat-map.
+- **Schedule cap:** Maximum 2 P0 items per week to avoid production bottlenecks. Items beyond the cap roll into the next available week.
+- **Duplicate guard:** If two candidates collapse to the same fuzzy question (≥ 80 % similarity), keep only the higher-scoring one.
+- **Sitemap fetch timeout:** 30 seconds. If the sitemap is unreachable, set status BLOCKED and abort emission.
+- **Intent purity:** No candidate may carry two intents. If disambiguation rules cannot resolve, split into two questions.
+
+---
+
+## Important Notes
+
+- This skill **plans** content. It does not write it. Page bodies are produced downstream by `geo-content`.
+- The 4-quadrant taxonomy is the canonical intent vocabulary for the entire fork. `geo-competitor-citation` reuses it verbatim. Do not introduce a fifth intent here without updating both downstream skills.
+- Search volume estimates are unreliable without a keyword tool wired up. When falling back to head/torso/tail heuristics, mark the SV cell with a `~` prefix in the output table to signal the estimate is rough.
+- The 2025 Profound citation distribution (31/27/24/18) is a population prior, not a per-topic guarantee. A site selling B2B compliance software will skew Causal-heavy; a site selling consumer electronics will skew Comparative-heavy. Treat the priors as defaults, not targets.
+- The matrix output file should be regenerated quarterly, not monthly. The 12-week schedule horizon matches one publishing quarter and a longer regeneration cycle would invalidate downstream pipeline runs.


### PR DESCRIPTION
…, distribution-plan, competitor-citation)

Forked from upstream commit 5d8c0af (zubair-trabzada/geo-seo-claude).

Adds 4 new skills wiring the existing audit/optimization skills into a closed 4-step GEO workflow (angles -> publish -> guide -> measure):

- geo-intent-matrix    (/geo matrix)     — 4-quadrant intent taxonomy +
                                            12-week rolling schedule. Emits
                                            the intent vocabulary consumed
                                            by the other 3 new skills.
- geo-citation-pipeline (/geo pipeline)  — 5-stage AI citation pipeline
                                            (crawlers / internal-link wiring
                                            / AI-training authority backlinks
                                            / on-page compliance / rapid
                                            indexing) + Stage 6 cross-engine
                                            preferred-answer verification.
- geo-distribution-plan (/geo distribute) — Tier 1/2/3 platform matrix,
                                             14-day cadence, per-platform
                                             rewrite briefs (Zhihu, WeChat,
                                             Xiaohongshu, CSDN/Juejin,
                                             LinkedIn, Medium, Substack,
                                             Reddit, HN, X, vertical media),
                                             7/14/30-day reclaim checklist.
- geo-competitor-citation (/geo compete) — 20 probes x 6 engines x 3 runs
                                            cross-engine gap matrix (brand x
                                            engine x intent) with verdict
                                            per quadrant and top-3
                                            remediation plan.

Orchestrator (geo/SKILL.md) updated to register the 4 new commands, adds a closure-loop section with diagram + example end-to-end run.

README adds an "About This Fork" block. NOTICE and FORK_CHANGELOG.md record attribution and the inception changelog. LICENSE is preserved verbatim. All existing upstream skills, agents, scripts, schemas, and install scripts are unmodified. No new Python dependencies required.