### PR TITLE
Add white-label brand config helper

### DIFF
--- a/white-label/README.md
+++ b/white-label/README.md
@@ -1,0 +1,60 @@
+# White-Label Branding for GEO Reports
+
+A small, framework-agnostic helper that lets agencies and resellers rebrand the
+GEO reports they generate — agency name, contact details, and colors — from a
+single `brand.json` file, **without editing any generator code**.
+
+This is useful because GEO agencies built on this tool typically deliver reports
+under their own brand. Today that means editing colors in the generator by hand;
+this drops that into one config file each reseller can keep.
+
+## How it works
+
+`brand_config.py` exposes one function, `load_brand()`, that returns a plain dict
+and deep-merges an optional `brand.json` over sensible defaults:
+
+```python
+from brand_config import load_brand
+
+brand = load_brand("brand.json")        # or load_brand() for defaults
+
+agency   = brand["name"]                 # "Your Agency Inc."
+primary  = brand["colors"]["primary"]    # "#19C3B2"
+contact  = brand["contact_name"]
+```
+
+Because it's just a dict, you can feed it into any report generator — ReportLab,
+HTML/Playwright, or anything else — wherever you currently hard-code colors or a
+company name.
+
+## Config
+
+Copy `brand.example.json` to `brand.json` and edit. Any field you omit keeps its
+default, so a reseller can override as little as a single color:
+
+```json
+{
+  "name": "Your Agency Inc.",
+  "website": "youragency.com",
+  "phone": "555-123-4567",
+  "contact_name": "Your Name",
+  "colors": {
+    "primary": "#19C3B2",
+    "text_accent": "#19C3B2"
+  }
+}
+```
+
+Keys: `name`, `cover_tag`, `website`, `phone`, `contact_name`, and a `colors`
+object (merged key-by-key). Keys starting with `_` (like `_comment`) are ignored.
+
+## Try it
+
+```bash
+python brand_config.py brand.json    # prints the merged brand dict
+```
+
+## Credit
+
+Contributed as a thank-you by Millisa Nwokolo (La Crown Inc.), built on top of the
+GEO-SEO Claude engine by Zubair Trabzada. MIT licensed.

--- a/white-label/brand.example.json
+++ b/white-label/brand.example.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Copy to brand.json and edit. Any field you omit keeps its default, so you can override as little as one color. Load it with: from brand_config import load_brand; brand = load_brand('brand.json')",
+
+  "name": "Your Agency Inc.",
+  "cover_tag": "Generative Engine Optimization Audit",
+  "website": "youragency.com",
+  "phone": "555-123-4567",
+  "contact_name": "Your Name",
+
+  "colors": {
+    "primary": "#19C3B2",
+    "primary_bright": "#3FE0CF",
+    "secondary": "#E94560",
+    "text_accent": "#19C3B2"
+  }
+}

--- a/white-label/brand_config.py
+++ b/white-label/brand_config.py
@@ -1,0 +1,69 @@
+"""
+White-label brand config loader for GEO-SEO Claude report generators.
+
+Lets agencies/resellers rebrand generated reports — name, contact details, and
+colors — from an external brand.json file, with no need to edit generator code.
+Framework-agnostic: works with any report generator (ReportLab, HTML/Playwright,
+etc.) by exposing a plain dict.
+
+Usage
+-----
+    from brand_config import load_brand
+
+    brand = load_brand("brand.json")     # deep-merges over DEFAULT_BRAND
+    title_color = brand["colors"]["primary"]
+    agency_name = brand["name"]
+
+Any field a config omits keeps its default, so a reseller can override as little
+as a single color. Keys beginning with "_" (e.g. "_comment") are ignored.
+
+Contributed by Millisa Nwokolo (La Crown Inc.) as a thank-you, built on top of
+the GEO-SEO Claude engine by Zubair Trabzada. MIT licensed.
+"""
+
+import json
+import os
+import copy
+
+DEFAULT_BRAND = {
+    "name": "Your Agency",
+    "cover_tag": "Generative Engine Optimization Audit",
+    "website": "youragency.com",
+    "phone": "",
+    "contact_name": "",
+    "colors": {
+        "primary":        "#E8A87C",   # headers, accents
+        "primary_bright": "#F0B98A",   # hover/highlight variant
+        "secondary":      "#E94560",   # gauges, CTAs
+        "bg_deep":        "#0A0A0F",
+        "bg_dark":        "#111118",
+        "bg_card":        "#1A1A28",
+        "border":         "#2A2A3A",
+        "text_primary":   "#F0EDE8",
+        "text_secondary": "#A09898",
+        "text_accent":    "#E8A87C",
+    },
+}
+
+
+def load_brand(config_path=None):
+    """Return a brand dict. If config_path points to a JSON file, deep-merge it
+    over the defaults (colors merge key-by-key; everything else overrides)."""
+    brand = copy.deepcopy(DEFAULT_BRAND)
+    if config_path and os.path.exists(config_path):
+        with open(config_path, "r", encoding="utf-8") as f:
+            cfg = json.load(f)
+        for key, value in cfg.items():
+            if key.startswith("_"):
+                continue
+            if key == "colors" and isinstance(value, dict):
+                brand["colors"].update(value)
+            else:
+                brand[key] = value
+    return brand
+
+
+if __name__ == "__main__":
+    import sys
+    path = sys.argv[1] if len(sys.argv) > 1 else None
+    print(json.dumps(load_brand(path), indent=2))


### PR DESCRIPTION
Thanks for building and open-sourcing this — it's been genuinely useful. As a small thank-you, here's an optional, self-contained white-label/ helper that lets agencies rebrand generated reports (name, contact, colors) from a single brand.json, without editing generator code. It's framework-agnostic — load_brand() just returns a dict — so it can plug into any of the report generators. Includes an example config and a short README. No changes to existing files. Feel free to use, adapt, or pass on it. Thanks again!