### PR TITLE
fix(install): install report templates dir for /geo report-pdf

### DIFF
--- a/install-win.sh
+++ b/install-win.sh
@@ -139,6 +139,7 @@ main() {
     mkdir -p "$INSTALL_DIR/scripts"
     mkdir -p "$INSTALL_DIR/schema"
     mkdir -p "$INSTALL_DIR/hooks"
+    mkdir -p "$INSTALL_DIR/templates"
 
     print_success "Directory structure created at: $CLAUDE_DIR"
 
@@ -215,6 +216,14 @@ main() {
         print_success "Schema templates installed -> ${INSTALL_DIR}/schema/"
     fi
 
+    # ---- Install Report Templates (pandoc HTML/CSS for /geo report-pdf) ----
+    print_info "Installing report templates..."
+
+    if [ -d "$SOURCE_DIR/templates" ]; then
+        cp -r "$SOURCE_DIR/templates/"* "$INSTALL_DIR/templates/"
+        print_success "Report templates installed -> ${INSTALL_DIR}/templates/"
+    fi
+
     # ---- Install Hooks ----
     if [ -d "$SOURCE_DIR/hooks" ] && [ "$(ls -A "$SOURCE_DIR/hooks" 2>/dev/null)" ]; then
         print_info "Installing hooks..."
@@ -268,6 +277,8 @@ main() {
                                           && print_success "Agent files"          || { print_error "Agent files missing";       VERIFY_OK=false; }
     [ -d "$INSTALL_DIR/scripts" ]         && print_success "Utility scripts"      || { print_error "Scripts missing";           VERIFY_OK=false; }
     [ -d "$INSTALL_DIR/schema" ]          && print_success "Schema templates"     || { print_error "Schema templates missing";  VERIFY_OK=false; }
+    [ -f "$INSTALL_DIR/templates/geo-report-template.html" ] \
+                                          && print_success "Report templates"     || { print_error "Report templates missing";  VERIFY_OK=false; }
 
     if [ "$VERIFY_OK" = false ]; then
         echo ""

--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,7 @@ main() {
     print_info "Creating directories..."
 
     mkdir -p "$SKILLS_DIR" "$AGENTS_DIR" "$INSTALL_DIR"
-    mkdir -p "$INSTALL_DIR/scripts" "$INSTALL_DIR/schema" "$INSTALL_DIR/hooks"
+    mkdir -p "$INSTALL_DIR/scripts" "$INSTALL_DIR/schema" "$INSTALL_DIR/hooks" "$INSTALL_DIR/templates"
 
     print_success "Directory structure created"
 
@@ -192,6 +192,13 @@ main() {
     if [ -d "$SOURCE_DIR/schema" ]; then
         cp -r "$SOURCE_DIR/schema/"* "$INSTALL_DIR/schema/"
         print_success "Schema templates installed → ${INSTALL_DIR}/schema/"
+    fi
+
+    # ---- Install Report Templates (pandoc HTML/CSS for /geo report-pdf) ----
+    print_info "Installing report templates..."
+    if [ -d "$SOURCE_DIR/templates" ]; then
+        cp -r "$SOURCE_DIR/templates/"* "$INSTALL_DIR/templates/"
+        print_success "Report templates installed → ${INSTALL_DIR}/templates/"
     fi
 
     # ---- Install Hooks ----
@@ -329,6 +336,7 @@ main() {
     verify "Agent files"           test "$agent_count" -gt 0
     verify "Utility scripts"       test -d "$INSTALL_DIR/scripts"
     verify "Schema templates"      test -d "$INSTALL_DIR/schema"
+    verify "Report templates"      test -f "$INSTALL_DIR/templates/geo-report-template.html"
     verify "Venv interpreter"      test -x "$VENV_PY"
 
     if [ "$VERIFY_OK" = false ]; then


### PR DESCRIPTION
## Problem

`/geo report-pdf` fails on a fresh install. Both `install.sh` and `install-win.sh` copy `scripts/`, `schema/`, and `hooks/` into `~/.claude/skills/geo/`, but **never copy the `templates/` directory** (the pandoc HTML/CSS report templates).

Meanwhile both `skills/geo-report-pdf/SKILL.md` and the main `geo/SKILL.md` reference:

- `~/.claude/skills/geo/templates/geo-report-template.html`
- `~/.claude/skills/geo/templates/geo-report-style.css`

So on a clean install those files are missing and pandoc errors out on the `--template` / `--css` paths.

## Fix

Add a "report templates" install step to **both** installers, mirroring the existing schema-template step:

- `mkdir -p "$INSTALL_DIR/templates"` in the directory-setup block
- `cp -r "$SOURCE_DIR/templates/"* "$INSTALL_DIR/templates/"`
- a `verify` line checking `templates/geo-report-template.html` exists

`uninstall.sh` already does `rm -rf "$SKILLS_DIR/geo"`, so it removes the templates dir with everything else — no change needed there.

## Testing

- `bash -n` passes on both scripts
- Ran the patched `install.sh` on macOS: `templates/geo-report-template.html` and `geo-report-style.css` now land in `~/.claude/skills/geo/templates/`, and the verify step reports `✓ Report templates`
- After the fix, `/geo report-pdf` renders the cover + report PDF end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)