### PR TITLE
fix(install): install report templates so /geo report-pdf works

### DIFF
--- a/install-win.sh
+++ b/install-win.sh
@@ -139,6 +139,7 @@ main() {
     mkdir -p "$INSTALL_DIR/scripts"
     mkdir -p "$INSTALL_DIR/schema"
     mkdir -p "$INSTALL_DIR/hooks"
+    mkdir -p "$INSTALL_DIR/templates"
 
     print_success "Directory structure created at: $CLAUDE_DIR"
 
@@ -215,6 +216,18 @@ main() {
         print_success "Schema templates installed -> ${INSTALL_DIR}/schema/"
     fi
 
+    # ---- Install Report Templates ----
+    # Required by the geo-report-pdf skill, which reads
+    # ~/.claude/skills/geo/templates/{geo-report-template.html,geo-report-style.css}
+    print_info "Installing report templates..."
+
+    if [ -d "$SOURCE_DIR/templates" ]; then
+        cp -r "$SOURCE_DIR/templates/"* "$INSTALL_DIR/templates/"
+        print_success "Report templates installed -> ${INSTALL_DIR}/templates/"
+    else
+        print_warning "templates/ not found in source - /geo report-pdf will not work."
+    fi
+
     # ---- Install Hooks ----
     if [ -d "$SOURCE_DIR/hooks" ] && [ "$(ls -A "$SOURCE_DIR/hooks" 2>/dev/null)" ]; then
         print_info "Installing hooks..."
@@ -268,6 +281,8 @@ main() {
                                           && print_success "Agent files"          || { print_error "Agent files missing";       VERIFY_OK=false; }
     [ -d "$INSTALL_DIR/scripts" ]         && print_success "Utility scripts"      || { print_error "Scripts missing";           VERIFY_OK=false; }
     [ -d "$INSTALL_DIR/schema" ]          && print_success "Schema templates"     || { print_error "Schema templates missing";  VERIFY_OK=false; }
+    [ -f "$INSTALL_DIR/templates/geo-report-template.html" ] \
+                                          && print_success "Report templates"     || { print_error "Report templates missing";  VERIFY_OK=false; }
 
     if [ "$VERIFY_OK" = false ]; then
         echo ""

--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,7 @@ main() {
     print_info "Creating directories..."
 
     mkdir -p "$SKILLS_DIR" "$AGENTS_DIR" "$INSTALL_DIR"
-    mkdir -p "$INSTALL_DIR/scripts" "$INSTALL_DIR/schema" "$INSTALL_DIR/hooks"
+    mkdir -p "$INSTALL_DIR/scripts" "$INSTALL_DIR/schema" "$INSTALL_DIR/hooks" "$INSTALL_DIR/templates"
 
     print_success "Directory structure created"
 
@@ -192,6 +192,17 @@ main() {
     if [ -d "$SOURCE_DIR/schema" ]; then
         cp -r "$SOURCE_DIR/schema/"* "$INSTALL_DIR/schema/"
         print_success "Schema templates installed → ${INSTALL_DIR}/schema/"
+    fi
+
+    # ---- Install Report Templates ----
+    # Required by the geo-report-pdf skill, which reads
+    # ~/.claude/skills/geo/templates/{geo-report-template.html,geo-report-style.css}
+    print_info "Installing report templates..."
+    if [ -d "$SOURCE_DIR/templates" ]; then
+        cp -r "$SOURCE_DIR/templates/"* "$INSTALL_DIR/templates/"
+        print_success "Report templates installed → ${INSTALL_DIR}/templates/"
+    else
+        print_warning "templates/ not found in source — /geo report-pdf will not work."
     fi
 
     # ---- Install Hooks ----
@@ -329,6 +340,7 @@ main() {
     verify "Agent files"           test "$agent_count" -gt 0
     verify "Utility scripts"       test -d "$INSTALL_DIR/scripts"
     verify "Schema templates"      test -d "$INSTALL_DIR/schema"
+    verify "Report templates"      test -f "$INSTALL_DIR/templates/geo-report-template.html"
     verify "Venv interpreter"      test -x "$VENV_PY"
 
     if [ "$VERIFY_OK" = false ]; then


### PR DESCRIPTION
## Problem

The `geo-report-pdf` skill reads two files from `~/.claude/skills/geo/templates/`:

- `geo-report-template.html`
- `geo-report-style.css`

Both are present in the repo under `templates/`, but **neither installer ever creates or populates that directory** — only `schema/` is handled. The `templates/` directory is never referenced in `install.sh` or `install-win.sh`.

The result is that on a fresh install, `/geo report-pdf` fails immediately — the pandoc invocation in the skill points at a `--template` path that does not exist, so no PDF can be produced. The failure is silent until someone actually tries to generate a report.

Reproduce on a clean machine:

```bash
curl -fsSL https://raw.githubusercontent.com/zubair-trabzada/geo-seo-claude/main/install.sh | bash
ls ~/.claude/skills/geo/templates/    # No such file or directory
```

## Fix

Adds the missing install step to **both** `install.sh` and `install-win.sh`, following the existing `schema/` pattern:

1. `mkdir -p "$INSTALL_DIR/templates"` alongside the other directories
2. Copy `templates/*` into it, with a `print_warning` if the source directory is absent
3. Add a `verify` check for `geo-report-template.html`, alongside the existing checks

No behaviour changes beyond the missing copy step. Nothing else touched.

## Verification

Ran the patched `install.sh` against a throwaway `HOME`:

```
→ Installing report templates...
✓ Report templates installed → .../.claude/skills/geo/templates/
...
✓ Report templates
```

Both files land correctly and the new verify check passes. `bash -n` clean on both scripts.

Confirmed end to end by generating two real client PDF reports (13pp and 12pp) once the templates were in place.