### PR TITLE
Fix sample client data leaking into every generated report; install templates/

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -194,6 +194,14 @@ main() {
         print_success "Schema templates installed → ${INSTALL_DIR}/schema/"
     fi
 
+    # ---- Install Report Templates ----
+    print_info "Installing report templates..."
+    if [ -d "$SOURCE_DIR/templates" ]; then
+        mkdir -p "$INSTALL_DIR/templates"
+        cp -r "$SOURCE_DIR/templates/"* "$INSTALL_DIR/templates/"
+        print_success "Report templates installed → ${INSTALL_DIR}/templates/"
+    fi
+
     # ---- Install Hooks ----
     if [ -d "$SOURCE_DIR/hooks" ] && [ "$(ls -A "$SOURCE_DIR/hooks" 2>/dev/null)" ]; then
         print_info "Installing hooks..."
@@ -329,6 +337,7 @@ main() {
     verify "Agent files"           test "$agent_count" -gt 0
     verify "Utility scripts"       test -d "$INSTALL_DIR/scripts"
     verify "Schema templates"      test -d "$INSTALL_DIR/schema"
+    verify "Report templates"      test -f "$INSTALL_DIR/templates/geo-report-template.html"
     verify "Venv interpreter"      test -x "$VENV_PY"
 
     if [ "$VERIFY_OK" = false ]; then

--- a/templates/geo-report-style.css
+++ b/templates/geo-report-style.css
@@ -403,9 +403,12 @@ h2.section-break { page-break-before: always; }
 }
 
 /* ---- Footer ---- */
+/* Footer text is overridden per-report by an inline <style> block in
+   geo-report-template.html (driven by the footer_text metadata field).
+   This value is a neutral fallback only — never put a client name here. */
 @page {
   @bottom-center {
-    content: "Alexa Media Solutions · GEO Audit · May 2026";
+    content: "GEO Audit";
     font-family: 'Inter', sans-serif;
     font-size: 7.5pt;
     color: #94a3b8;

--- a/templates/geo-report-template.html
+++ b/templates/geo-report-template.html
@@ -6,6 +6,19 @@
   <title>$title$</title>
   $for(css)$<link rel="stylesheet" href="$css$">
   $endfor$
+  <style>
+    /* Per-report page footer. Overrides the neutral fallback in the stylesheet.
+       Falls back to the brand name so a client's report never carries another
+       client's name. */
+    @page {
+      @bottom-center {
+        content: "$if(footer_text)$$footer_text$$else$$if(brand_name)$$brand_name$ · GEO Audit$else$GEO Audit$endif$$endif$";
+        font-family: 'Inter', sans-serif;
+        font-size: 7.5pt;
+        color: #94a3b8;
+      }
+    }
+  </style>
 </head>
 <body>
 
@@ -13,31 +26,34 @@
 <div id="cover-section">
   <p class="cover-eyebrow">Generative Engine Optimization Audit</p>
   <h1>$if(brand_name)$$brand_name$$else$GEO Audit Report$endif$</h1>
-  <p class="cover-domain">$if(domain)$$domain$$else$alexamediasolutions.com$endif$</p>
+  <p class="cover-domain">$domain$</p>
 
   <div class="geo-score-badge">
-    <span class="score-number">$if(geo_score)$$geo_score$$else$40$endif$</span>
+    <span class="score-number">$if(geo_score)$$geo_score$$else$—$endif$</span>
     <span class="score-denom">/100</span>
-    <span class="score-label">$if(score_label)$$score_label$$else$Poor$endif$</span>
+    <span class="score-label">$score_label$</span>
   </div>
 
+  <!-- Meta fields render only when supplied. Never default these to sample
+       data — an unset field silently inheriting another client's details is
+       how a report ships with the wrong company on the cover. -->
   <div class="cover-meta-grid">
-    <div class="cover-meta-item">
+    $if(date)$<div class="cover-meta-item">
       <span class="label">Audit Date</span>
-      <span class="value">$if(date)$$date$$else$May 3, 2026$endif$</span>
-    </div>
-    <div class="cover-meta-item">
+      <span class="value">$date$</span>
+    </div>$endif$
+    $if(business_type)$<div class="cover-meta-item">
       <span class="label">Business Type</span>
-      <span class="value">$if(business_type)$$business_type$$else$Digital Marketing Agency$endif$</span>
-    </div>
-    <div class="cover-meta-item">
+      <span class="value">$business_type$</span>
+    </div>$endif$
+    $if(locations)$<div class="cover-meta-item">
       <span class="label">Locations</span>
-      <span class="value">$if(locations)$$locations$$else$Raleigh · Miami · Denver · Omaha$endif$</span>
-    </div>
-    <div class="cover-meta-item">
+      <span class="value">$locations$</span>
+    </div>$endif$
+    $if(platform)$<div class="cover-meta-item">
       <span class="label">Platform</span>
-      <span class="value">$if(platform)$$platform$$else$WordPress + AIOSEO$endif$</span>
-    </div>
+      <span class="value">$platform$</span>
+    </div>$endif$
   </div>
 </div>
 


### PR DESCRIPTION
Hit both of these generating my first report with `/geo report-pdf`. Two independent bugs, both in the PDF pipeline.

## 1. Sample client data appears in every generated report

The page footer is hardcoded in `templates/geo-report-style.css`:

```css
@page {
  @bottom-center {
    content: "Alexa Media Solutions · GEO Audit · May 2026";
```

Because it lives in a CSS `@page` rule rather than the pandoc template, **no metadata flag can override it** — every report produced by the skill carries that name on every page. My 15-page audit for an unrelated company shipped with it on all 15 before I caught it.

`templates/geo-report-template.html` compounds this by defaulting unset cover fields to the same sample client:

| Field | Default |
|---|---|
| `domain` | `alexamediasolutions.com` |
| `locations` | `Raleigh · Miami · Denver · Omaha` |
| `platform` | `WordPress + AIOSEO` |
| `business_type` | `Digital Marketing Agency` |
| `date` | `May 3, 2026` |

This fires often in practice because `skills/geo-report-pdf/SKILL.md` instructs the caller to omit `--metadata` flags for fields it can't find in the audit report, describing the fallbacks as "sensible defaults". My site is a SaaS with no physical locations and runs Next.js, so the cover asserted four cities it has no presence in and the wrong CMS.

**Fix:** footer text now comes from a `footer_text` metadata field, falling back to `<brand_name> · GEO Audit`, then to a bare `GEO Audit`. Cover meta fields render only when supplied — a missing field now shows nothing instead of someone else's details. The CSS fallback is a neutral string with a comment warning against putting a client name there.

## 2. `install.sh` never copies `templates/`

The installer handles `geo/`, `skills/`, `agents/`, `scripts/`, `schema/` and `hooks/`, but not `templates/`. On a fresh install `~/.claude/skills/geo/templates/` doesn't exist, so `/geo report-pdf` fails at the pandoc step with a missing-template error. Added the copy alongside the others plus a matching verification check.

## Testing

Rendered a fixture report twice — once with full metadata, once with `brand_name` only:

- Footer resolves correctly in both (`Acme · GEO Audit` in the minimal case)
- Optional cover fields omit cleanly rather than falling back
- Zero occurrences of `alexa` / `raleigh` / `AIOSEO` / `Digital Marketing Agency` in either output

Also regenerated my real 15-page report end to end and confirmed via `pdftotext | grep` that no sample-client strings survive.

## Not addressed here

Keeping this focused, but two portability issues in the same skill worth a separate look: `SKILL.md` hardcodes the macOS Chrome path (`/Applications/Google Chrome.app/...`) and `brew install`, and uses pandoc's `--embed-resources`, which only exists in pandoc ≥ 2.19 — Ubuntu 20.04/22.04 ship 2.9, where the flag is `--self-contained`. Both need local workarounds on Linux. Happy to send a follow-up PR if you'd like it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)