### PR TITLE
Test crawler reachability, and stop scoring retired Google features

### DIFF
--- a/skills/geo-crawlers/SKILL.md
+++ b/skills/geo-crawlers/SKILL.md
@@ -217,6 +217,31 @@ Disallow: /
 
 ## Analysis Procedure
 
+### Step 0: Live reachability test — DO THIS FIRST
+
+**`robots.txt` states a policy. It does not enforce one.** Enforcement happens at the CDN, WAF or origin, and those layers frequently disagree with the file — most often because a managed "block AI bots" control blocks the whole AI-crawler *category*, including answering crawlers the site deliberately allows. A site can publish a perfectly-reasoned allowlist and still return 403 to every crawler on it.
+
+Every other step in this skill analyses a stated policy. This step is the only one that measures what actually happens, and it is the one most likely to find something that matters. **Never report crawler access from `robots.txt` alone.**
+
+1. Pick a real content URL (not the homepage alone — test a deep page too).
+2. Request it once per crawler using the full User-Agent strings from the reference table above. Record the HTTP status for each.
+3. **Run negative controls in the same pass.** Without them the result is uninterpretable:
+
+| Control | Purpose | If it returns 403 |
+|---|---|---|
+| An invented UA (`TotallyMadeUpBot/1.0`) | Detects a blanket non-browser block | The block is generic, not AI-specific |
+| A spoofed *conventional* crawler (`Googlebot`, `bingbot`) | Detects verified-bot enforcement | The server rejects unverified bots by IP; your AI results are inconclusive |
+| The same bot URL under a different token (`SomeBot/1.0; +claudebot@anthropic.com`) | Isolates what the rule matches | Combined with a 403 for `ClaudeBot/1.0`, proves the rule matches the **token name** |
+
+4. Also test `/robots.txt`, `/llms.txt` and `/sitemap.xml` individually. A configuration that serves `robots.txt` but 403s `llms.txt` tells a compliant crawler it is welcome and then refuses it the file it was pointed at.
+5. Inspect the 403 response itself. Security headers that differ from the site's own (e.g. `X-Frame-Options: SAMEORIGIN` where the site sends `DENY`) indicate the block is generated at the edge and never reached the origin.
+
+**Interpreting the result.** If invented and conventional-crawler UAs return 200 while AI-crawler tokens return 403, the block is a UA-name match and applies to real crawlers too. If everything unusual returns 403, you are seeing generic bot mitigation and cannot conclude anything about AI crawlers specifically — say so rather than reporting a finding.
+
+**State the limitation in the report.** Testing from outside cannot prove that a crawler arriving from its operator's verified IP range is treated identically to a spoofed UA. Recommend confirming in the CDN's own bot analytics, which report per-crawler allow/block counts by name. Report this as high-confidence-with-caveat, never as certainty.
+
+**Severity.** An answering crawler that `robots.txt` allows but the edge blocks is **Critical** — it is a total loss of reachability for that platform, and no content, schema or `llms.txt` work has any effect until it is fixed. Rank it above every content finding.
+
 ### Step 1: Fetch and Parse robots.txt
 
 1. Use WebFetch to retrieve `[domain]/robots.txt`.

--- a/skills/geo-schema/SKILL.md
+++ b/skills/geo-schema/SKILL.md
@@ -136,7 +136,13 @@ The Author schema is one of the strongest E-E-A-T signals for AI platforms.
 - `material`, `weight`, `width`, `height` (where applicable)
 
 ### FAQPage
-**Status as of 2024**: Google restricts FAQ rich results to government and health sites. However, the FAQPage schema still serves GEO purposes — AI platforms parse FAQ structured data for question-answer extraction. Implement it for AI readability even though rich results may not appear.
+**Status — Google retired FAQ rich results for ALL sites on 7 May 2026.** The earlier govt/health restriction (Aug 2023) is obsolete history; the feature is now gone entirely, along with the Search Console appearance filter, the rich-results report and Rich Results Test support.
+
+`FAQPage` remains a **valid Schema.org type** and is still parsed by Bing and by AI retrieval systems. So it is worth adding — but the justification is **AI citation only**, and it must be presented that way. It gives a retrieval system pre-segmented, individually-quotable answer units instead of a prose blob it has to chunk itself.
+
+**Never present FAQPage as a rich-result or SERP win. It cannot produce one on Google.** If a report implies otherwise, the recommendation will be priced wrongly and may be prioritised above work that actually moves visibility.
+
+**Apply only to genuinely Q&A-structured pages.** Retrofitting `FAQPage` across a site that is not written as questions and answers is page weight for zero return.
 
 **Structure:**
 - `@type`: "FAQPage"
@@ -156,21 +162,22 @@ The Author schema is one of the strongest E-E-A-T signals for AI platforms.
 - `softwareVersion`: Current version
 - `releaseNotes`: Link to changelog
 
-### WebSite + SearchAction (for sitelinks search box)
-**Structure:**
+### WebSite (keep) + SearchAction (do NOT recommend)
+
+**`WebSite` is still worth having** — it establishes the site as an entity, carries `inLanguage` and `publisher`, and gives other nodes a stable `@id` to reference via `isPartOf`. Recommend it.
+
+**`SearchAction` should not be recommended. Google retired the sitelinks search box on 21 November 2024** and removed the associated Search Console report and Rich Results Test highlighting. The markup now drives no feature on Google. Google's own guidance is that removing existing `SearchAction` markup is unnecessary — unsupported structured data causes no errors — so **do not raise its presence as a defect either**. It is simply inert.
+
+Recommending it is markup for a feature that no longer exists, and it is the same class of error as recommending `speakable` to an ineligible site or pricing `FAQPage` as a rich-result win. Treat all three as one decision.
+
 ```json
 {
   "@type": "WebSite",
+  "@id": "https://example.com/#website",
   "name": "Site Name",
   "url": "https://example.com",
-  "potentialAction": {
-    "@type": "SearchAction",
-    "target": {
-      "@type": "EntryPoint",
-      "urlTemplate": "https://example.com/search?q={search_term_string}"
-    },
-    "query-input": "required name=search_term_string"
-  }
+  "inLanguage": "en-GB",
+  "publisher": { "@id": "https://example.com/#business" }
 }
 ```
 
@@ -180,8 +187,19 @@ Use as a standalone schema on About/Bio pages. This builds the entity graph for 
 **Required:** `name`, `url`
 **Recommended for GEO:** `sameAs`, `jobTitle`, `worksFor`, `knowsAbout`, `alumniOf`, `award`, `description`, `image`
 
-### speakable Property (for voice/AI assistants)
-The `speakable` property marks specific sections of content as particularly suitable for voice and AI assistant consumption. Add to Article or WebPage schemas.
+### speakable Property — CHECK ELIGIBILITY BEFORE RECOMMENDING
+
+`speakable` is still marked **BETA** in Google's documentation and is limited on three axes simultaneously:
+
+| Restriction | Requirement |
+|---|---|
+| Content type | **News articles only** |
+| Language | **English only** |
+| Audience location | **United States only** |
+
+**A site must satisfy all three to be eligible.** Most sites satisfy none of them. Recommending `speakable` to a non-news site, a non-English site, or one whose audience is outside the US is markup for a feature that site cannot be eligible for — the same error as recommending `SearchAction` or pricing `FAQPage` as a rich-result win.
+
+**Decision rule:** recommend `speakable` only for English-language news publishers with a US audience. For every other site, do not raise it — neither as a recommendation nor as a missing-feature deduction.
 
 ```json
 {
@@ -192,7 +210,8 @@ The `speakable` property marks specific sections of content as particularly suit
   }
 }
 ```
-This signals to AI assistants which passages are the best candidates for citation or reading aloud.
+
+Where it *is* eligible, selectors must resolve to concise, self-contained factual text. A selector pointing at navigation or a wall of prose is worse than omitting the property.
 
 ---
 
@@ -200,8 +219,10 @@ This signals to AI assistants which passages are the best candidates for citatio
 
 | Schema | Status | Note |
 |---|---|---|
-| HowTo | Rich results deprecated Aug 2023 | Still useful for AI parsing, but do not promise rich results |
-| FAQPage | Restricted to govt/health Aug 2023 | Still useful for AI parsing (see above) |
+| HowTo | Rich results deprecated Aug 2023 | Still parsed by AI systems, but do not promise rich results |
+| FAQPage | **Rich results retired for ALL sites 7 May 2026** | Markup still valid and still parsed by AI systems. AI-citation justification only — never present as a SERP win |
+| SearchAction / sitelinks search box | **Retired 21 Nov 2024** | Do not recommend. Do not flag as missing. `WebSite` itself is still worth keeping |
+| speakable | BETA; news + English + US only | Check all three before recommending. Do not deduct points from ineligible sites |
 | SpecialAnnouncement | Deprecated 2023 | Was for COVID; remove if still present |
 | CourseInfo | Replaced by Course updates 2024 | Use updated Course schema properties |
 | VideoObject `contentUrl` | Changed behavior 2024 | Must point to actual video file, not page URL |
@@ -246,7 +267,7 @@ The `sameAs` property is the single most important structured data property for 
 Based on the detected business type, generate ready-to-paste JSON-LD blocks. Always generate:
 
 1. **Organization or Person** (depending on entity type) — always
-2. **WebSite with SearchAction** — always for the homepage
+2. **WebSite** — always for the homepage. Include `@id`, `inLanguage` and `publisher`; **omit `SearchAction`** (retired 21 Nov 2024)
 3. **Business-type-specific** — Article for publishers, Product for e-commerce, LocalBusiness for local, SoftwareApplication for SaaS
 4. **BreadcrumbList** — for any page deeper than homepage
 
@@ -255,7 +276,8 @@ Based on the detected business type, generate ready-to-paste JSON-LD blocks. Alw
 - All URLs must be absolute (not relative)
 - Include `@id` properties for cross-referencing between schemas
 - Use ISO 8601 for all dates
-- Include `speakable` on Article schemas with CSS selectors pointing to key content sections
+- Include `speakable` on Article schemas **only where the site is eligible** — English-language news, US audience. Omit it otherwise
+- Emit **one `<script type="application/ld+json">` per page containing a single `@graph`**. Splitting nodes across multiple script tags makes cross-block `@id` references unreliable: Google usually merges same-page blocks, but many third-party and AI parsers resolve nothing across blocks, silently dropping `author` and `publisher`
 - Place JSON-LD in `<head>` section — NOT injected via JavaScript
 
 ### Template: Organization with Full GEO Signals
@@ -314,17 +336,20 @@ Based on the detected business type, generate ready-to-paste JSON-LD blocks. Alw
 
 ## Scoring Rubric (0-100)
 
+**Scoring principle — never deduct for a feature the site cannot use.** Before scoring any criterion, check the site is eligible for it. If it is not (wrong content type, wrong language, wrong region, or the platform feature has been retired), the criterion **does not apply**: remove its points from the denominator and rescale, rather than scoring 0. Scoring 0 for correctly-absent markup manufactures a deficit, misdirects the remediation plan, and penalises a site for being right.
+
 | Criterion | Points | How to Score |
 |---|---|---|
 | Organization/Person schema present and complete | 15 | 15 if full, 10 if basic, 0 if none |
 | sameAs links (5+ platforms) | 15 | 3 per valid sameAs link, max 15 |
 | Article schema with author details | 10 | 10 if full author schema, 5 if name only, 0 if none |
 | Business-type-specific schema present | 10 | 10 if complete, 5 if partial, 0 if missing |
-| WebSite + SearchAction | 5 | 5 if present, 0 if not |
+| WebSite node present (with `@id`) | 5 | 5 if present, 0 if not. **Do not score `SearchAction`** — retired 21 Nov 2024; its absence is correct, not a defect |
 | BreadcrumbList on inner pages | 5 | 5 if present, 0 if not |
 | JSON-LD format (not Microdata/RDFa) | 5 | 5 if JSON-LD, 3 if mixed, 0 if only Microdata/RDFa |
 | Server-rendered (not JS-injected) | 10 | 10 if in HTML source, 5 if JS but in head, 0 if dynamic JS |
-| speakable property on articles | 5 | 5 if present, 0 if not |
+| Single `@graph` per page (no cross-block `@id`) | 5 | 5 if one block, 2 if multiple blocks resolve, 0 if references dangle |
+| speakable property on articles | 5 | **Only score if the site is eligible** (English news, US audience). If ineligible, this criterion does not apply — remove its 5 points from the denominator rather than scoring 0 |
 | Valid JSON + valid Schema.org types | 10 | 10 if no errors, 5 if minor issues, 0 if major errors |
 | knowsAbout property on Organization/Person | 5 | 5 if present with 3+ topics, 0 if missing |
 | No deprecated schemas present | 5 | 5 if clean, 0 if deprecated schemas found |


### PR DESCRIPTION
Two independent bugs found while running a full site audit with this skill. Both are generalisable — neither is specific to the site that surfaced them.

## 1. `geo-crawlers` never tests whether crawlers can actually reach the site

The analysis procedure has six steps — parse `robots.txt`, check meta robots, check headers, check AI files, check JS rendering, parse content signals. **None fetches the site with a crawler user-agent.** The 30-line UA reference table is documentation, never used as a test.

`robots.txt` states a policy; the CDN or WAF enforces one, and they often disagree. A managed "block AI bots" control typically blocks the whole AI-crawler *category*, including the answering crawlers a site deliberately allows — so a site can publish a well-reasoned allowlist and still 403 every crawler on it. It is invisible to analytics, because analytics counts humans.

On the site that surfaced this, every answering crawler `robots.txt` explicitly allowed — `OAI-SearchBot`, `ChatGPT-User`, `Claude-User`, `Claude-SearchBot`, `PerplexityBot`, `Amazonbot` — was returning **403 at the edge**, including on `/llms.txt` itself. So a compliant engine read `robots.txt`, was told it was welcome, was pointed at `llms.txt`, and was then refused it. The skill had no way to detect that, and found it only by accident when `WebFetch` calls started failing.

Adds **Step 0: Live reachability test** as the first step, with **negative controls** so the result is interpretable:

| Control | Detects |
|---|---|
| Invented UA (`TotallyMadeUpBot/1.0`) | A blanket non-browser block |
| Spoofed conventional crawler (`Googlebot`) | Verified-bot enforcement by IP |
| Same bot URL, different token | Whether the rule matches the **token name** |

Without those you cannot distinguish a real block from bot-impersonation defence. Also tests `/robots.txt`, `/llms.txt` and `/sitemap.xml` individually, checks whether the 403 came from the edge or the origin, and requires stating the verified-IP limitation rather than claiming certainty. Severity: **Critical** — no content, schema or `llms.txt` work has any effect until it is fixed.

## 2. `geo-schema` recommends and scores retired Google features

The scoring rubric awarded **5 points for `WebSite + SearchAction`** and **5 for `speakable`**, so a site loses 10 points for correctly *not* shipping markup that drives no feature.

| Feature | Rubric assumed | Actual |
|---|---|---|
| `SearchAction` | Scored as required | Sitelinks search box [retired 21 Nov 2024](https://developers.google.com/search/blog/2024/11/sitelinks-search-box) |
| `speakable` | Scored unconditionally | [BETA — news articles, English, US audience only](https://developers.google.com/search/docs/appearance/structured-data/speakable) |
| `FAQPage` | "restricted to govt/health, Aug 2023" | Rich results **retired for all sites 7 May 2026**. Markup still valid and still parsed by AI systems |

`FAQPage` is still worth adding — but on an **AI-citation** justification, never as a SERP win, and the difference changes how it gets prioritised.

Changes: current dates and status on all three; `SearchAction` dropped from recommendations and scoring (and explicitly *not* flagged as missing, since unsupported markup causes no errors); `speakable` gated on eligibility; deprecation table corrected and extended.

Adds a general scoring principle — **never deduct for a feature the site cannot use**; rescale the denominator rather than scoring 0. Scoring 0 for correctly-absent markup manufactures a deficit and misdirects the remediation plan.

Also adds a single-`@graph`-per-page generation rule: cross-block `@id` references are usually merged by Google but frequently unresolved by third-party and AI parsers, which silently drops `author` and `publisher`.

## Notes

- Documentation only — 2 files, +70/−20. No behavioural code, no new dependencies.
- The retirement dates will age. They are stated with sources so the next reader can re-check rather than re-derive.
- Separately, and not included here to keep this focused: `install.sh` does not copy `templates/`, but `geo-report-pdf` references `templates/geo-report-template.html` and `geo-report-style.css` by absolute path — so a standard install has a broken PDF path. Happy to send that as its own PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
