### PR TITLE
Fix: installers never copy templates/, breaking /geo report-pdf

### DIFF
--- a/install-win.sh
+++ b/install-win.sh
@@ -139,6 +139,7 @@ main() {
     mkdir -p "$INSTALL_DIR/scripts"
     mkdir -p "$INSTALL_DIR/schema"
     mkdir -p "$INSTALL_DIR/hooks"
+    mkdir -p "$INSTALL_DIR/templates"
 
     print_success "Directory structure created at: $CLAUDE_DIR"
 
@@ -215,6 +216,18 @@ main() {
         print_success "Schema templates installed -> ${INSTALL_DIR}/schema/"
     fi
 
+    # ---- Install Report Templates ----
+    # geo-report-pdf references these by absolute path
+    # (~/.claude/skills/geo/templates/), so /geo report-pdf fails without them.
+    print_info "Installing report templates..."
+
+    if [ -d "$SOURCE_DIR/templates" ] && [ "$(ls -A "$SOURCE_DIR/templates" 2>/dev/null)" ]; then
+        cp -r "$SOURCE_DIR/templates/"* "$INSTALL_DIR/templates/"
+        print_success "Report templates installed -> ${INSTALL_DIR}/templates/"
+    else
+        print_warning "templates/ not found in source -- /geo report-pdf will not work."
+    fi
+
     # ---- Install Hooks ----
     if [ -d "$SOURCE_DIR/hooks" ] && [ "$(ls -A "$SOURCE_DIR/hooks" 2>/dev/null)" ]; then
         print_info "Installing hooks..."
@@ -268,6 +281,8 @@ main() {
                                           && print_success "Agent files"          || { print_error "Agent files missing";       VERIFY_OK=false; }
     [ -d "$INSTALL_DIR/scripts" ]         && print_success "Utility scripts"      || { print_error "Scripts missing";           VERIFY_OK=false; }
     [ -d "$INSTALL_DIR/schema" ]          && print_success "Schema templates"     || { print_error "Schema templates missing";  VERIFY_OK=false; }
+    [ -f "$INSTALL_DIR/templates/geo-report-template.html" ] \
+                                          && print_success "Report templates"     || { print_error "Report templates missing";  VERIFY_OK=false; }
 
     if [ "$VERIFY_OK" = false ]; then
         echo ""

--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,7 @@ main() {
     print_info "Creating directories..."
 
     mkdir -p "$SKILLS_DIR" "$AGENTS_DIR" "$INSTALL_DIR"
-    mkdir -p "$INSTALL_DIR/scripts" "$INSTALL_DIR/schema" "$INSTALL_DIR/hooks"
+    mkdir -p "$INSTALL_DIR/scripts" "$INSTALL_DIR/schema" "$INSTALL_DIR/hooks" "$INSTALL_DIR/templates"
 
     print_success "Directory structure created"
 
@@ -192,6 +192,17 @@ main() {
     if [ -d "$SOURCE_DIR/schema" ]; then
         cp -r "$SOURCE_DIR/schema/"* "$INSTALL_DIR/schema/"
         print_success "Schema templates installed → ${INSTALL_DIR}/schema/"
+    fi
+
+    # ---- Install Report Templates ----
+    # geo-report-pdf references these by absolute path
+    # (~/.claude/skills/geo/templates/), so /geo report-pdf fails without them.
+    print_info "Installing report templates..."
+    if [ -d "$SOURCE_DIR/templates" ] && [ "$(ls -A "$SOURCE_DIR/templates" 2>/dev/null)" ]; then
+        cp -r "$SOURCE_DIR/templates/"* "$INSTALL_DIR/templates/"
+        print_success "Report templates installed → ${INSTALL_DIR}/templates/"
+    else
+        print_warning "templates/ not found in source — /geo report-pdf will not work."
     fi
 
     # ---- Install Hooks ----
@@ -329,6 +340,7 @@ main() {
     verify "Agent files"           test "$agent_count" -gt 0
     verify "Utility scripts"       test -d "$INSTALL_DIR/scripts"
     verify "Schema templates"      test -d "$INSTALL_DIR/schema"
+    verify "Report templates"      test -f "$INSTALL_DIR/templates/geo-report-template.html"
     verify "Venv interpreter"      test -x "$VENV_PY"
 
     if [ "$VERIFY_OK" = false ]; then


### PR DESCRIPTION
Both `install.sh` and `install-win.sh` create and populate `scripts/`, `schema/` and `hooks/` under the install directory — but neither copies `templates/`.

`geo-report-pdf` and `geo/SKILL.md` reference the two files in that directory **by absolute path**:

```
~/.claude/skills/geo/templates/geo-report-template.html
~/.claude/skills/geo/templates/geo-report-style.css
```

There are eight such references across the two files. Because the pandoc invocation passes them as `--template` and `--css`, a standard install fails at that step with a missing-file error rather than degrading gracefully — so **`/geo report-pdf` is broken on every fresh install, on both platforms**.

I hit this doing a real audit: everything else worked, and the PDF step failed on a file the installer had never placed.

## Changes

- `templates/` added to the `mkdir` list in both installers
- Copied alongside the existing `schema` block
- A verification line added, so a future regression is caught by the installer's own checks rather than by a user running the command

The copy uses the same `[ -d ] && [ "$(ls -A ...)" ]` guard the `hooks` block already uses in these files, so an absent or empty `templates/` warns and continues instead of aborting under `set -euo pipefail`.

## Verification

- `bash -n` passes on both scripts
- The copy places both files and the new verify gate passes
- Absent `templates/` and empty `templates/` both skip cleanly without tripping `set -e`

Separate from #73 and independent of it — either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
