### PR TITLE
chore: publish star history via GitHub Pages

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -11,22 +11,51 @@ permissions:
 jobs:
   update-chart:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Generate SVGs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 .github/scripts/star_history.py
 
-      - name: Commit if changed
+      - name: Publish SVGs to gh-pages
         run: |
+          # Keep the generated files before switching branches
+          cp assets/star-history.svg /tmp/star-history.svg
+          cp assets/star-history-dark.svg /tmp/star-history-dark.svg
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add assets/star-history.svg assets/star-history-dark.svg
+
+          # Clean generated changes from main before switching branches
+          git reset --hard HEAD
+          git clean -fd
+
+          # If gh-pages already exists, check it out.
+          # Otherwise create a completely independent orphan branch.
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git fetch origin gh-pages:gh-pages
+            git switch gh-pages
+          else
+            git switch --orphan gh-pages
+            git rm -rf . || true
+          fi
+
+          # gh-pages contains ONLY the published assets
+          cp /tmp/star-history.svg star-history.svg
+          cp /tmp/star-history-dark.svg star-history-dark.svg
+          touch .nojekyll
+
+          git add star-history.svg star-history-dark.svg .nojekyll
+
           if git diff --cached --quiet; then
             echo "No changes"
           else
             git commit -m "chore: update star history chart"
-            git push
+            git push origin gh-pages
           fi

--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@
 
 <a href="https://www.star-history.com/#zubair-trabzada/geo-seo-claude&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="assets/star-history-dark.svg">
-    <img alt="Star History Chart" src="assets/star-history.svg">
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://zubair-trabzada.github.io/geo-seo-claude/star-history-dark.svg">
+    <img
+      alt="Star History Chart"
+      src="https://zubair-trabzada.github.io/geo-seo-claude/star-history.svg">
   </picture>
 </a>
 


### PR DESCRIPTION
Hello! This keeps the commit history clean.
Moves star-history to GitHub Pages.
Once you manually run it, it will create the gh-pages branch.

2. Go to **Settings → Pages**.
3. Under **Build and deployment**, set **Source** to **Deploy from a branch**.
4. Select the **`gh-pages`** branch.
5. Select **`/ (root)`** as the folder.
6. Click **Save**.
7. Wait until GitHub Pages finishes deploying, then verify that these URLs load correctly:

   * `https://zubair-trabzada.github.io/geo-seo-claude/star-history.svg`
   * `https://zubair-trabzada.github.io/geo-seo-claude/star-history-dark.svg`

The `gh-pages` branch is intentionally an orphan branch and should contain only the generated SVG 
files and `.nojekyll`.


🎁